### PR TITLE
feat: auto-update via GitHub Releases with build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,29 @@
-name: Tauri Build
+name: Build and Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release type"
+        required: true
+        default: "prerelease"
+        type: choice
+        options:
+          - prerelease
+          - release
+      version_increment:
+        description: "Version increment type"
+        required: false
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      release_name:
+        description: "Release name (leave empty to auto-generate)"
+        required: false
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always
@@ -9,10 +31,15 @@ env:
 
 jobs:
   build:
-    name: Tauri Build
+    name: Build and Release
     runs-on: windows-latest
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -31,15 +58,137 @@ jobs:
       - name: npm ci
         run: npm ci
 
-      - name: cargo tauri build
-        run: cargo install tauri-cli --version "^2" && cargo tauri build
+      - name: Prepare version
+        id: version
+        shell: pwsh
+        run: |
+          # Read current version from Cargo.toml
+          $cargoToml = Get-Content "src-tauri/Cargo.toml" -Raw
+          if ($cargoToml -match 'version\s*=\s*"(\d+)\.(\d+)\.(\d+)"') {
+              $major = [int]$matches[1]
+              $minor = [int]$matches[2]
+              $patch = [int]$matches[3]
+          } else {
+              Write-Error "Could not parse version from Cargo.toml"
+              exit 1
+          }
+
+          $increment = "${{ github.event.inputs.version_increment }}"
+          switch ($increment) {
+              'major' { $major++; $minor=0; $patch=0 }
+              'minor' { $minor++; $patch=0 }
+              'patch' { $patch++ }
+          }
+
+          $version = "$major.$minor.$patch"
+          $tagName = "v$version"
+          $buildTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss")
+
+          Write-Host "New version: $version"
+
+          # Update Cargo.toml
+          $cargoToml = $cargoToml -replace 'version\s*=\s*"\d+\.\d+\.\d+"', "version = `"$version`""
+          $cargoToml | Set-Content "src-tauri/Cargo.toml" -NoNewline
+
+          # Update tauri.conf.json5
+          $tauriConf = Get-Content "src-tauri/tauri.conf.json5" -Raw
+          $tauriConf = $tauriConf -replace '"version":\s*"\d+\.\d+\.\d+"', "`"version`": `"$version`""
+          $tauriConf | Set-Content "src-tauri/tauri.conf.json5" -NoNewline
+
+          # Update package.json
+          $pkgJson = Get-Content "package.json" -Raw
+          $pkgJson = $pkgJson -replace '"version":\s*"\d+\.\d+\.\d+"', "`"version`": `"$version`""
+          $pkgJson | Set-Content "package.json" -NoNewline
+
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "tag_name=$tagName" >> $env:GITHUB_OUTPUT
+          "build_time=$buildTime" >> $env:GITHUB_OUTPUT
+
+      - name: Build Tauri app
+        run: cargo tauri build
         env:
           TAURI_SIGNING_PRIVATE_KEY: ""
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Copy standalone exe
+        shell: pwsh
+        run: |
+          Copy-Item "src-tauri/target/release/maplelink.exe" "MapleLink.exe"
+          $hash = (Get-FileHash "MapleLink.exe" -Algorithm SHA256).Hash
+          "sha256=$hash" >> $env:GITHUB_OUTPUT
+          Write-Host "SHA256: $hash"
+          Write-Host "Size: $((Get-Item MapleLink.exe).Length) bytes"
+        id: artifact
+
+      - name: Prepare release notes
+        id: notes
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $repoUrl = "${{ github.server_url }}/${{ github.repository }}"
+          $lastRelease = gh api repos/${{ github.repository }}/releases --paginate 2>$null | ConvertFrom-Json | Sort-Object created_at -Descending | Select-Object -First 1
+          $range = if ($lastRelease) { "$($lastRelease.tag_name)..HEAD" } else { "-n 30" }
+          $commits = git log $range --pretty=format:"- [%h]($repoUrl/commit/%H) %s" --no-merges 2>$null
+          $commitCount = if ($commits) { ($commits -split "`n").Count } else { 0 }
+          $commitsText = if ($commits) { $commits -join "`n" } else { "Initial release" }
+
+          $delimiter = "EOF_$([guid]::NewGuid().ToString('N'))"
+          "commits<<$delimiter" >> $env:GITHUB_OUTPUT
+          $commitsText >> $env:GITHUB_OUTPUT
+          $delimiter >> $env:GITHUB_OUTPUT
+          "count=$commitCount" >> $env:GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: maplelink-build
-          path: |
-            src-tauri/target/release/bundle/nsis/*.exe
-          retention-days: 7
+          tag_name: ${{ steps.version.outputs.tag_name }}
+          name: >
+            ${{
+              github.event.inputs.release_name != ''
+                && github.event.inputs.release_name
+                || format('v{0}', steps.version.outputs.version)
+            }}
+          body: |
+            **Version:** v${{ steps.version.outputs.version }}
+            **Type:** ${{ github.event.inputs.release_type == 'release' && 'Release' || 'Pre-Release' }}
+            **Built:** ${{ steps.version.outputs.build_time }} UTC
+
+            ---
+
+            ### Download
+            **[MapleLink.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag_name }}/MapleLink.exe)** — standalone, no installation needed
+
+            ### Changes
+            ${{ steps.notes.outputs.commits }}
+
+            (${{ steps.notes.outputs.count }} commits)
+
+            ### Usage
+            1. Download **MapleLink.exe**
+            2. Place in any folder and run
+            3. First launch will auto-extract locale emulation files
+
+            ${{ github.event.inputs.release_type == 'prerelease' && '> ⚠️ This is a pre-release. Use at your own risk.' || '' }}
+
+            <details>
+            <summary>Details</summary>
+
+            | Item | Value |
+            |------|-------|
+            | SHA256 | `${{ steps.artifact.outputs.sha256 }}` |
+            | Build Time | ${{ steps.version.outputs.build_time }} UTC |
+            | Commit | [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}) |
+
+            </details>
+          files: MapleLink.exe
+          draft: false
+          prerelease: ${{ github.event.inputs.release_type == 'prerelease' }}
+
+      - name: Commit version bump
+        shell: pwsh
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src-tauri/Cargo.toml src-tauri/tauri.conf.json5 package.json
+          git diff --cached --quiet || git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+          git push

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,7 +1,4 @@
 //! Tauri commands for the auto-update system.
-//!
-//! Thin wrappers that delegate to [`crate::services::update_service`] and
-//! respect the `auto_update` toggle in [`AppConfig`].
 
 use tauri::State;
 
@@ -11,12 +8,7 @@ use crate::models::error::ErrorDto;
 use crate::models::update::UpdateInfo;
 use crate::services::update_service;
 
-/// Check for an available update.
-///
-/// When `manual` is `false` (startup check), the command respects the
-/// `auto_update` config toggle — returning `Ok(None)` immediately if
-/// auto-update is disabled. When `manual` is `true`, the check always
-/// proceeds regardless of the toggle.
+/// Check GitHub Releases for an available update.
 #[tauri::command]
 pub async fn check_update(
     manual: Option<bool>,
@@ -27,51 +19,51 @@ pub async fn check_update(
     if !is_manual {
         let config = state.config.read().await;
         if !update_service::should_check_on_startup(config.auto_update) {
-            tracing::info!("auto-update disabled, skipping startup check");
             return Ok(None);
         }
     }
 
     let version = update_service::current_version();
-
     update_service::check_for_update(&state.http_client, version)
         .await
-        .map_err(|e| {
-            let app_err: AppError = e.into();
-            ErrorDto::from(app_err)
-        })
+        .map_err(|e| ErrorDto::from(AppError::from(e)))
 }
 
-/// Download and apply an available update.
-///
-/// The caller should have previously called `check_update` to obtain the
-/// [`UpdateInfo`]. This command downloads the binary, stages it, and
-/// signals that a restart is needed.
+/// Download and stage the update installer. Returns the installer path.
 #[tauri::command]
 pub async fn apply_update(
     download_url: String,
+    use_proxy: Option<bool>,
     state: State<'_, AppState>,
-) -> Result<(), ErrorDto> {
-    let bytes = update_service::download_update(&state.http_client, &download_url)
-        .await
-        .map_err(|e| {
-            let app_err: AppError = e.into();
-            ErrorDto::from(app_err)
-        })?;
+) -> Result<String, ErrorDto> {
+    let url = update_service::get_download_url(&download_url, use_proxy.unwrap_or(false));
 
-    // Stage the update in a temp directory next to the config.
+    let bytes = update_service::download_update(&state.http_client, &url)
+        .await
+        .map_err(|e| ErrorDto::from(AppError::from(e)))?;
+
     let staging_dir = state
         .config_path
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("updates");
 
-    update_service::apply_update(&bytes, &staging_dir)
+    let path = update_service::apply_update(&bytes, &staging_dir)
         .await
-        .map_err(|e| {
-            let app_err: AppError = e.into();
-            ErrorDto::from(app_err)
-        })?;
+        .map_err(|e| ErrorDto::from(AppError::from(e)))?;
 
-    Ok(())
+    // Launch the installer
+    #[cfg(target_os = "windows")]
+    {
+        use std::process::Command;
+        let _ = Command::new(&path).spawn();
+    }
+
+    Ok(path.display().to_string())
+}
+
+/// Test if GitHub is directly reachable (for ghproxy detection).
+#[tauri::command]
+pub async fn test_github_access(state: State<'_, AppState>) -> Result<bool, ErrorDto> {
+    Ok(update_service::test_github_connectivity(&state.http_client).await)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,6 +157,7 @@ pub fn run() {
             commands::auth::gamepass_webview_done,
             commands::update::check_update,
             commands::update::apply_update,
+            commands::update::test_github_access,
         ])
         // -- Setup (startup sequence) ---------------------------------------
         .setup(|app| {

--- a/src-tauri/src/models/update.rs
+++ b/src-tauri/src/models/update.rs
@@ -9,6 +9,7 @@ pub struct UpdateInfo {
     pub version: String,
     pub changelog: String,
     pub download_url: String,
+    pub is_prerelease: bool,
 }
 
 /// Current status of an update operation.

--- a/src-tauri/src/services/update_service.rs
+++ b/src-tauri/src/services/update_service.rs
@@ -1,70 +1,113 @@
-//! Auto-update service — checks for updates, downloads, and applies them.
+//! Auto-update service — checks GitHub Releases for updates.
 //!
-//! All network failures are handled gracefully: logged and surfaced as
-//! [`UpdateError`] variants so the application can continue without
-//! interruption.
+//! Supports ghproxy.com mirror for users in mainland China.
 
 use crate::core::error::UpdateError;
 use crate::models::update::UpdateInfo;
 
-/// The update endpoint URL template. `{current_version}` is replaced at
-/// runtime with the running application version.
-const UPDATE_ENDPOINT: &str = "https://releases.maplelink.app/check?version={current_version}";
+/// GitHub API endpoint for latest release.
+const GITHUB_API_URL: &str = "https://api.github.com/repos/lshw54/maplelink/releases/latest";
 
-/// Check the remote endpoint for an available update.
-///
-/// Returns `Ok(Some(UpdateInfo))` when a newer version exists, `Ok(None)`
-/// when the application is already up-to-date, or an `UpdateError` on
-/// network / parse failures.
+/// ghproxy mirror prefix for accelerated downloads in China.
+const GHPROXY_PREFIX: &str = "https://mirror.ghproxy.com/";
+
+/// Check GitHub Releases for an available update.
 pub async fn check_for_update(
     client: &reqwest::Client,
     current_version: &str,
 ) -> Result<Option<UpdateInfo>, UpdateError> {
-    let url = UPDATE_ENDPOINT.replace("{current_version}", current_version);
-
-    tracing::info!("checking for updates at {url}");
+    tracing::info!("checking for updates (current: v{current_version})");
 
     let response = client
-        .get(&url)
+        .get(GITHUB_API_URL)
+        .header("User-Agent", "MapleLink-Updater")
+        .header("Accept", "application/vnd.github.v3+json")
         .timeout(std::time::Duration::from_secs(15))
         .send()
         .await
-        .map_err(|e| {
-            tracing::warn!("update check network error: {e}");
-            UpdateError::CheckFailed {
-                reason: format!("network error: {e}"),
-            }
+        .map_err(|e| UpdateError::CheckFailed {
+            reason: format!("network error: {e}"),
         })?;
 
-    if response.status() == reqwest::StatusCode::NO_CONTENT {
-        tracing::info!("no update available (already up-to-date)");
-        return Ok(None);
-    }
-
     if !response.status().is_success() {
-        let status = response.status();
-        tracing::warn!("update check returned HTTP {status}");
         return Err(UpdateError::CheckFailed {
-            reason: format!("HTTP {status}"),
+            reason: format!("HTTP {}", response.status()),
         });
     }
 
-    let info: UpdateInfo = response.json().await.map_err(|e| {
-        tracing::warn!("failed to parse update response: {e}");
-        UpdateError::CheckFailed {
-            reason: format!("invalid response body: {e}"),
-        }
-    })?;
+    let release: serde_json::Value =
+        response
+            .json()
+            .await
+            .map_err(|e| UpdateError::CheckFailed {
+                reason: format!("invalid response: {e}"),
+            })?;
 
-    tracing::info!("update available: v{}", info.version);
-    Ok(Some(info))
+    let tag = release["tag_name"]
+        .as_str()
+        .unwrap_or("")
+        .trim_start_matches('v');
+
+    if tag.is_empty() {
+        return Ok(None);
+    }
+
+    // Compare versions
+    if !is_newer(tag, current_version) {
+        tracing::info!("no update available (latest: v{tag})");
+        return Ok(None);
+    }
+
+    // Find the .exe asset (standalone exe, not NSIS installer)
+    let download_url = release["assets"]
+        .as_array()
+        .and_then(|assets| {
+            assets.iter().find_map(|a| {
+                let name = a["name"].as_str().unwrap_or("");
+                if name.to_lowercase().ends_with(".exe") {
+                    a["browser_download_url"].as_str().map(String::from)
+                } else {
+                    None
+                }
+            })
+        })
+        .unwrap_or_default();
+
+    let changelog = release["body"].as_str().unwrap_or("").to_string();
+    let is_prerelease = release["prerelease"].as_bool().unwrap_or(false);
+
+    tracing::info!("update available: v{tag} (prerelease={is_prerelease})");
+
+    Ok(Some(UpdateInfo {
+        version: tag.to_string(),
+        changelog,
+        download_url,
+        is_prerelease,
+    }))
 }
 
-/// Download the update binary from the given URL.
-///
-/// Returns the raw bytes on success. Corrupt or incomplete downloads are
-/// detected by checking the HTTP status and content length, then discarded
-/// with a logged error.
+/// Get the download URL, optionally proxied through ghproxy for China users.
+pub fn get_download_url(original_url: &str, use_proxy: bool) -> String {
+    if use_proxy && !original_url.is_empty() {
+        format!("{GHPROXY_PREFIX}{original_url}")
+    } else {
+        original_url.to_string()
+    }
+}
+
+/// Test if GitHub API is reachable (for detecting if user needs ghproxy).
+pub async fn test_github_connectivity(client: &reqwest::Client) -> bool {
+    client
+        .head("https://api.github.com")
+        .header("User-Agent", "MapleLink-Updater")
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+}
+
+/// Download the update binary.
 pub async fn download_update(
     client: &reqwest::Client,
     download_url: &str,
@@ -73,97 +116,71 @@ pub async fn download_update(
 
     let response = client
         .get(download_url)
+        .header("User-Agent", "MapleLink-Updater")
         .timeout(std::time::Duration::from_secs(300))
         .send()
         .await
-        .map_err(|e| {
-            tracing::error!("update download network error: {e}");
-            UpdateError::DownloadFailed {
-                reason: format!("network error: {e}"),
-            }
+        .map_err(|e| UpdateError::DownloadFailed {
+            reason: format!("network error: {e}"),
         })?;
 
     if !response.status().is_success() {
-        let status = response.status();
-        tracing::error!("update download returned HTTP {status}");
         return Err(UpdateError::DownloadFailed {
-            reason: format!("HTTP {status}"),
+            reason: format!("HTTP {}", response.status()),
         });
     }
 
-    let expected_len = response.content_length();
-    let bytes = response.bytes().await.map_err(|e| {
-        tracing::error!("failed to read update body: {e}");
-        UpdateError::DownloadFailed {
-            reason: format!("failed to read response body: {e}"),
-        }
-    })?;
-
-    // Verify content length if the server provided one.
-    if let Some(expected) = expected_len {
-        if bytes.len() as u64 != expected {
-            tracing::error!(
-                "update download size mismatch: expected {expected}, got {}",
-                bytes.len()
-            );
-            return Err(UpdateError::CorruptDownload);
-        }
-    }
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| UpdateError::DownloadFailed {
+            reason: format!("read error: {e}"),
+        })?;
 
     if bytes.is_empty() {
-        tracing::error!("update download returned empty body");
         return Err(UpdateError::CorruptDownload);
     }
 
-    tracing::info!("update downloaded successfully ({} bytes)", bytes.len());
+    tracing::info!("downloaded {} bytes", bytes.len());
     Ok(bytes.to_vec())
 }
 
-/// Apply a downloaded update.
-///
-/// This is a placeholder that writes the update payload to a staging path
-/// and signals that a restart is needed. The actual installer/replacement
-/// logic depends on the packaging strategy (NSIS, MSI, etc.) and will be
-/// wired in during integration.
+/// Save downloaded update to a temp file and launch the installer.
 pub async fn apply_update(
     update_bytes: &[u8],
     staging_dir: &std::path::Path,
-) -> Result<(), UpdateError> {
-    tracing::info!("applying update ({} bytes)", update_bytes.len());
-
-    tokio::fs::create_dir_all(staging_dir).await.map_err(|e| {
-        tracing::error!("failed to create staging directory: {e}");
-        UpdateError::DownloadFailed {
-            reason: format!("failed to create staging dir: {e}"),
-        }
-    })?;
-
-    let installer_path = staging_dir.join("maplelink_update.exe");
-
-    tokio::fs::write(&installer_path, update_bytes)
+) -> Result<std::path::PathBuf, UpdateError> {
+    tokio::fs::create_dir_all(staging_dir)
         .await
-        .map_err(|e| {
-            tracing::error!("failed to write update installer: {e}");
-            UpdateError::DownloadFailed {
-                reason: format!("failed to write installer: {e}"),
-            }
+        .map_err(|e| UpdateError::DownloadFailed {
+            reason: format!("failed to create staging dir: {e}"),
         })?;
 
-    tracing::info!(
-        "update staged at {}; restart required to complete",
-        installer_path.display()
-    );
-    Ok(())
+    let installer_path = staging_dir.join("MapleLink_update.exe");
+    tokio::fs::write(&installer_path, update_bytes)
+        .await
+        .map_err(|e| UpdateError::DownloadFailed {
+            reason: format!("failed to write installer: {e}"),
+        })?;
+
+    tracing::info!("update staged at {}", installer_path.display());
+    Ok(installer_path)
 }
 
-/// Determine whether an auto-update check should run based on config.
-///
-/// Pure helper — returns `true` only when `auto_update` is enabled.
+/// Simple semver comparison: returns true if `new` > `current`.
+fn is_newer(new: &str, current: &str) -> bool {
+    let parse = |s: &str| -> Vec<u32> { s.split('.').filter_map(|p| p.parse().ok()).collect() };
+    let n = parse(new);
+    let c = parse(current);
+    n > c
+}
+
+/// Determine whether an auto-update check should run.
 pub fn should_check_on_startup(auto_update_enabled: bool) -> bool {
     auto_update_enabled
 }
 
-/// Current application version read from `Cargo.toml` at compile time.
+/// Current application version from Cargo.toml.
 pub fn current_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
@@ -173,32 +190,28 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    // Feature: maplelink-rewrite, Property 11: Disabled auto-update skips update check
-    //
-    // For any AppConfig where auto_update is false, the startup sequence
-    // shall not invoke the update check endpoint.
-    proptest! {
-        #[test]
-        fn prop_disabled_auto_update_skips_check(
-            // Generate a random bool that is always false for the disabled case.
-            _dummy in 0u8..10,
-        ) {
-            // When auto_update is disabled, should_check_on_startup must return false.
-            prop_assert!(!should_check_on_startup(false));
-        }
-
-        #[test]
-        fn prop_enabled_auto_update_allows_check(
-            _dummy in 0u8..10,
-        ) {
-            // When auto_update is enabled, should_check_on_startup must return true.
-            prop_assert!(should_check_on_startup(true));
-        }
+    #[test]
+    fn is_newer_works() {
+        assert!(is_newer("0.2.0", "0.1.0"));
+        assert!(is_newer("1.0.0", "0.9.9"));
+        assert!(!is_newer("0.1.0", "0.1.0"));
+        assert!(!is_newer("0.0.9", "0.1.0"));
     }
 
     #[test]
     fn current_version_is_non_empty() {
-        let v = current_version();
-        assert!(!v.is_empty());
+        assert!(!current_version().is_empty());
+    }
+
+    proptest! {
+        #[test]
+        fn prop_disabled_auto_update_skips_check(_dummy in 0u8..10) {
+            prop_assert!(!should_check_on_startup(false));
+        }
+
+        #[test]
+        fn prop_enabled_auto_update_allows_check(_dummy in 0u8..10) {
+            prop_assert!(should_check_on_startup(true));
+        }
     }
 }

--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -9,7 +9,8 @@ import { AccountGrid } from "./AccountGrid";
 import { OtpPanel } from "./OtpPanel";
 import { StatusBar } from "../shared/StatusBar";
 import { Modal } from "../shared/Modal";
-import type { GameAccountDto } from "../../lib/types";
+import { UpdateDialog } from "../shared/UpdateDialog";
+import type { GameAccountDto, UpdateInfoDto } from "../../lib/types";
 
 export function MainPage() {
   const { t } = useTranslation();
@@ -22,6 +23,7 @@ export function MainPage() {
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
   const [launching, setLaunching] = useState(false);
   const [pid, setPid] = useState<number | null>(null);
+  const [pendingUpdate, setPendingUpdate] = useState<UpdateInfoDto | null>(null);
 
   // Poll game process status — clear pid when process exits
   useEffect(() => {
@@ -61,6 +63,13 @@ export function MainPage() {
     commands
       .getAppVersion()
       .then(setAppVersion)
+      .catch(() => {});
+    // Check for updates
+    commands
+      .checkUpdate()
+      .then((info) => {
+        if (info) setPendingUpdate(info);
+      })
       .catch(() => {});
     // Auto-detect game path if not set
     const currentConfig = useConfigStore.getState().config;
@@ -355,6 +364,11 @@ export function MainPage() {
           </div>
         </div>
       </Modal>
+
+      {/* Update dialog */}
+      {pendingUpdate && (
+        <UpdateDialog update={pendingUpdate} onClose={() => setPendingUpdate(null)} />
+      )}
     </div>
   );
 }

--- a/src/features/shared/UpdateDialog.tsx
+++ b/src/features/shared/UpdateDialog.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "../../lib/i18n";
+import { commands } from "../../lib/tauri";
+import { Modal } from "./Modal";
+import type { UpdateInfoDto } from "../../lib/types";
+
+interface Props {
+  update: UpdateInfoDto;
+  onClose: () => void;
+}
+
+export function UpdateDialog({ update, onClose }: Props) {
+  const { t } = useTranslation();
+  const [downloading, setDownloading] = useState(false);
+  const [needsProxy, setNeedsProxy] = useState(false);
+  const [useProxy, setUseProxy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Test GitHub connectivity on mount
+  useEffect(() => {
+    commands
+      .testGithubAccess()
+      .then((ok) => {
+        if (!ok) {
+          setNeedsProxy(true);
+          setUseProxy(true);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  async function handleDownload() {
+    setDownloading(true);
+    setError(null);
+    try {
+      await commands.applyUpdate(update.downloadUrl, useProxy);
+      // Installer launched — app will close
+    } catch (e) {
+      setError(
+        typeof e === "object" && e !== null && "message" in e
+          ? String((e as Record<string, unknown>).message)
+          : "Download failed",
+      );
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <Modal isOpen onClose={onClose} title={t("update.title")}>
+      <div className="flex flex-col gap-4">
+        {/* Version badge */}
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-gradient-to-br from-accent to-[#c47a1a] text-lg font-bold text-white shadow-lg">
+            ↑
+          </div>
+          <div>
+            <div className="text-sm font-semibold text-[var(--text)]">
+              v{update.version}
+              {update.isPrerelease && (
+                <span className="ml-2 rounded bg-[rgba(232,162,58,0.15)] px-1.5 py-0.5 text-[10px] text-accent">
+                  PRE
+                </span>
+              )}
+            </div>
+            <div className="text-[11px] text-text-dim">{t("update.new_version_available")}</div>
+          </div>
+        </div>
+
+        {/* Changelog */}
+        {update.changelog && (
+          <div className="max-h-[160px] overflow-y-auto rounded-lg bg-[var(--surface)] p-3 text-[11px] leading-relaxed text-text-dim">
+            {update.changelog.split("\n").map((line, i) => (
+              <div key={i}>{line || "\u00A0"}</div>
+            ))}
+          </div>
+        )}
+
+        {/* Proxy toggle (shown only when GitHub is slow/blocked) */}
+        {needsProxy && (
+          <label className="flex items-center gap-2 text-[11px] text-text-dim">
+            <input
+              type="checkbox"
+              checked={useProxy}
+              onChange={(e) => setUseProxy(e.target.checked)}
+              className="h-3.5 w-3.5 accent-accent"
+            />
+            {t("update.use_mirror")}
+          </label>
+        )}
+
+        {error && <div className="text-[11px] text-[var(--danger)]">{error}</div>}
+
+        {/* Actions */}
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={downloading}
+            className="rounded-lg px-4 py-1.5 text-[12px] text-text-dim transition-colors hover:bg-[var(--surface-hover)]"
+          >
+            {t("update.skip")}
+          </button>
+          <button
+            onClick={handleDownload}
+            disabled={downloading || !update.downloadUrl}
+            className="rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-4 py-1.5 text-[12px] font-semibold text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+          >
+            {downloading ? t("update.downloading") : t("update.download")}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/toolbox/AboutTab.tsx
+++ b/src/features/toolbox/AboutTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "../../lib/i18n";
 import { commands } from "../../lib/tauri";
+import { UpdateDialog } from "../shared/UpdateDialog";
 import type { UpdateInfoDto } from "../../lib/types";
 
 export function AboutTab() {
@@ -8,6 +9,7 @@ export function AboutTab() {
   const [appVersion, setAppVersion] = useState("0.1.0");
   const [checking, setChecking] = useState(false);
   const [updateResult, setUpdateResult] = useState<UpdateInfoDto | null | undefined>(undefined);
+  const [showUpdateDialog, setShowUpdateDialog] = useState(false);
 
   useEffect(() => {
     commands
@@ -22,6 +24,7 @@ export function AboutTab() {
     try {
       const info = await commands.checkUpdate();
       setUpdateResult(info);
+      if (info) setShowUpdateDialog(true);
     } catch {
       setUpdateResult(null);
     } finally {
@@ -31,7 +34,6 @@ export function AboutTab() {
 
   return (
     <div className="flex flex-col items-center gap-4 py-6">
-      {/* App icon */}
       <img src="/app-icon.png" alt="MapleLink" className="h-16 w-16 rounded-[16px] shadow-lg" />
 
       <div className="flex flex-col items-center gap-1">
@@ -45,7 +47,6 @@ export function AboutTab() {
         {t("toolbox.about.description")}
       </p>
 
-      {/* Check for Updates */}
       <button
         onClick={handleCheckUpdate}
         disabled={checking}
@@ -53,7 +54,7 @@ export function AboutTab() {
       >
         {checking ? t("toolbox.about.checking_update") : t("toolbox.about.check_update")}
       </button>
-      {updateResult !== undefined && (
+      {updateResult !== undefined && !showUpdateDialog && (
         <span className={`text-[12px] ${updateResult ? "text-accent" : "text-text-faint"}`}>
           {updateResult
             ? t("toolbox.about.update_available").replace("{{version}}", updateResult.version)
@@ -63,7 +64,7 @@ export function AboutTab() {
 
       <div className="flex flex-col items-center gap-1 text-[12px] text-text-dim">
         <a
-          href="https://github.com/maplelink"
+          href="https://github.com/lshw54/maplelink"
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent hover:underline"
@@ -72,6 +73,10 @@ export function AboutTab() {
         </a>
         <span>{t("toolbox.about.license")}</span>
       </div>
+
+      {showUpdateDialog && updateResult && (
+        <UpdateDialog update={updateResult} onClose={() => setShowUpdateDialog(false)} />
+      )}
     </div>
   );
 }

--- a/src/lib/hooks/use-update.ts
+++ b/src/lib/hooks/use-update.ts
@@ -20,9 +20,9 @@ export function useCheckUpdate() {
 
 /** Apply a downloaded update. */
 export function useApplyUpdate() {
-  return useMutation<undefined, Error>({
-    mutationFn: async () => {
-      await commands.applyUpdate();
+  return useMutation<undefined, Error, { downloadUrl: string; useProxy?: boolean }>({
+    mutationFn: async ({ downloadUrl, useProxy }) => {
+      await commands.applyUpdate(downloadUrl, useProxy);
     },
   });
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -67,8 +67,10 @@ export const commands = {
   setConfig: (key: string, value: string) => invoke("set_config", { key, value }),
 
   // Update
-  checkUpdate: () => invoke<UpdateInfoDto | null>("check_update"),
-  applyUpdate: () => invoke("apply_update"),
+  checkUpdate: () => invoke<UpdateInfoDto | null>("check_update", { manual: true }),
+  applyUpdate: (downloadUrl: string, useProxy?: boolean) =>
+    invoke<string>("apply_update", { downloadUrl, useProxy }),
+  testGithubAccess: () => invoke<boolean>("test_github_access"),
 
   // System
   resizeWindow: (page: string) => invoke("resize_window", { page }),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,7 @@ export interface UpdateInfoDto {
   version: string;
   changelog: string;
   downloadUrl: string;
+  isPrerelease: boolean;
 }
 
 export interface QrCodeData {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -128,6 +128,13 @@
   "toolbox.about.no_update": "You're up to date",
   "toolbox.about.update_available": "Update available: v{{version}}",
 
+  "update.title": "Update Available",
+  "update.new_version_available": "A new version is ready to download",
+  "update.download": "Download & Install",
+  "update.downloading": "Downloading...",
+  "update.skip": "Later",
+  "update.use_mirror": "Use mirror (recommended for China mainland)",
+
   "shared.titlebar.minimize": "Minimize",
   "shared.titlebar.maximize": "Maximize",
   "shared.titlebar.close": "Close",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -128,6 +128,13 @@
   "toolbox.about.no_update": "已是最新版本",
   "toolbox.about.update_available": "有可用更新：v{{version}}",
 
+  "update.title": "有可用更新",
+  "update.new_version_available": "新版本已准备好下载",
+  "update.download": "下载并安装",
+  "update.downloading": "下载中...",
+  "update.skip": "稍后",
+  "update.use_mirror": "使用镜像加速（建议中国大陆用户开启）",
+
   "shared.titlebar.minimize": "最小化",
   "shared.titlebar.maximize": "最大化",
   "shared.titlebar.close": "关闭",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -134,6 +134,13 @@
   "toolbox.about.no_update": "已是最新版本",
   "toolbox.about.update_available": "有可用更新：v{{version}}",
 
+  "update.title": "有可用更新",
+  "update.new_version_available": "新版本已準備好下載",
+  "update.download": "下載並安裝",
+  "update.downloading": "下載中...",
+  "update.skip": "稍後",
+  "update.use_mirror": "使用鏡像加速（建議中國大陸用戶開啟）",
+
   "shared.titlebar.minimize": "最小化",
   "shared.titlebar.maximize": "最大化",
   "shared.titlebar.close": "關閉",


### PR DESCRIPTION
- Build workflow: manual trigger, version bump, standalone exe release
- Update service: GitHub Releases API, ghproxy mirror for China
- Update dialog: version badge, changelog, proxy toggle, download/skip
- AboutTab: check update button opens same dialog, correct GitHub link
- Three-language translations for update UI