### PR TITLE
fix(launcher): multi-account session & region correctness + transparent window

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -367,9 +367,10 @@ pub async fn change_account_display_name(
     let _bf_lock = ss.bf_client_lock.lock().await;
 
     let session_guard = ss.session.read().await;
-    let _session = auth::require_valid_session(&session_guard).map_err(to_dto)?;
+    let session = auth::require_valid_session(&session_guard).map_err(to_dto)?;
 
-    let region = state.config.read().await.region.clone();
+    // Session's region, not the global config toggle (matches this account).
+    let region = session.region.clone();
     let game_code = format!("{}_{}", DEFAULT_SERVICE_CODE, DEFAULT_SERVICE_REGION);
 
     let success = beanfun_service::change_display_name(

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -652,12 +652,17 @@ pub async fn open_gash_popup(
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
     }
 
-    let config = state.config.read().await;
-    let (host, region_path) = match config.region {
+    // Use the SESSION's region (the account being viewed), NOT the global config
+    // toggle — otherwise a TW account opens HK URLs (seeded with the TW session's
+    // cookies → beanfun serves a logged-out page = a fake logout).
+    let region = match ss.session.read().await.as_ref() {
+        Some(s) => s.region.clone(),
+        None => state.config.read().await.region.clone(),
+    };
+    let (host, region_path) = match region {
         crate::models::session::Region::HK => ("bfweb.hk.beanfun.com", "HK"),
         crate::models::session::Region::TW => ("tw.beanfun.com", "TW"),
     };
-    drop(config);
 
     // Step 1: Call auth.aspx via reqwest to establish server-side session
     let auth_url = format!("https://{host}/{region_path}/auth.aspx");
@@ -883,8 +888,12 @@ pub async fn open_member_popup(
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
     }
 
-    let config = state.config.read().await;
-    let (host, region_path, page_query) = match config.region {
+    // Session's region, not the global config toggle (see open_gash_popup).
+    let region = match ss.session.read().await.as_ref() {
+        Some(s) => s.region.clone(),
+        None => state.config.read().await.region.clone(),
+    };
+    let (host, region_path, page_query) = match region {
         crate::models::session::Region::HK => (
             "bfweb.hk.beanfun.com",
             "HK",
@@ -892,7 +901,6 @@ pub async fn open_member_popup(
         ),
         crate::models::session::Region::TW => ("tw.beanfun.com", "TW", "index_new.aspx"),
     };
-    drop(config);
 
     let token = get_web_token_from_jar(&ss.cookie_jar, &state).await?;
     let url = format!(
@@ -977,20 +985,27 @@ pub async fn open_member_popup(
 /// Customer service pages don't require auth — open in internal WebView popup.
 #[tauri::command]
 pub async fn open_customer_service(
+    session_id: String,
     app: tauri::AppHandle,
     state: tauri::State<'_, crate::models::app_state::AppState>,
 ) -> Result<(), ErrorDto> {
-    let config = state.config.read().await;
-    let url = match config.region {
+    // Region from the active session, not the global config toggle.
+    let region = match state.get_session(&session_id).await {
+        Some(ss) => match ss.session.read().await.as_ref() {
+            Some(s) => s.region.clone(),
+            None => state.config.read().await.region.clone(),
+        },
+        None => state.config.read().await.region.clone(),
+    };
+    let url = match region {
         crate::models::session::Region::HK => {
             "https://bfweb.hk.beanfun.com/newfaq/service_newBF.aspx"
         }
         crate::models::session::Region::TW => {
             "https://tw.beanfun.com/customerservice/www/main.aspx"
         }
-    };
-    let url = url.to_string();
-    drop(config);
+    }
+    .to_string();
 
     open_web_popup(url, "客服中心".to_string(), app, state).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -591,8 +591,22 @@ pub fn run() {
             if let tauri::WindowEvent::Focused(true) = event {
                 if let Ok(hwnd) = window.hwnd() {
                     unsafe {
+                        const DWMWA_WINDOW_CORNER_PREFERENCE: u32 = 33;
                         const DWMWA_BORDER_COLOR: u32 = 34;
-                        let color: u32 = 0xFFFFFFFE; // DWMWCP_NONE
+                        const DWMWCP_ROUND: u32 = 2;
+                        const DWM_COLOR_NONE: u32 = 0xFFFFFFFE;
+                        // Round the window corners so the DWM shadow follows the
+                        // rounded shape (the window is transparent, so the CSS
+                        // border-radius defines the visible edge — no black corner).
+                        let round = DWMWCP_ROUND;
+                        let _ = windows_sys::Win32::Graphics::Dwm::DwmSetWindowAttribute(
+                            hwnd.0,
+                            DWMWA_WINDOW_CORNER_PREFERENCE,
+                            &round as *const _ as *const _,
+                            std::mem::size_of::<u32>() as u32,
+                        );
+                        // Remove the DWM border colour (no black hairline border).
+                        let color: u32 = DWM_COLOR_NONE;
                         let _ = windows_sys::Win32::Graphics::Dwm::DwmSetWindowAttribute(
                             hwnd.0,
                             DWMWA_BORDER_COLOR,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -521,14 +521,43 @@ pub fn run() {
                 }
             });
 
-            // 6. Session keep-alive is handled by the frontend (MainPage pings
-            //    ONLY the active session every 60s). We deliberately do NOT run a
-            //    backend loop that pings *every* session: keep-aliving all logged-in
-            //    accounts at once is a signal 3-4 separate browsers never produce,
-            //    and it made beanfun drop the inactive sessions when several
-            //    accounts were logged in ("login 3, only 1 survives"). Inactive
-            //    beanfun sessions stay valid for a long time on their own, just
-            //    like a background browser tab, so no background ping is needed.
+            // 6. Backend ping loop — keeps every logged-in session alive (~60s).
+            let ping_app = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                // Wait for at least one session to exist
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                    if let Some(state) = ping_app.try_state::<AppState>() {
+                        if !state.sessions.read().await.is_empty() {
+                            break;
+                        }
+                    }
+                }
+                tracing::info!("backend ping loop started");
+
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    if let Some(state) = ping_app.try_state::<AppState>() {
+                        let sessions = state.sessions.read().await;
+                        if sessions.is_empty() {
+                            tracing::info!("backend ping loop stopped (no sessions)");
+                            break;
+                        }
+                        for ss in sessions.values() {
+                            let region = {
+                                let session = ss.session.read().await;
+                                session.as_ref().map(|s| s.region.clone())
+                            };
+                            if let Some(region) = region {
+                                if let Ok(_guard) = ss.bf_client_lock.try_lock() {
+                                    services::beanfun_service::ping(&ss.http_client, &region).await;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
 
             // Only resize the initial window when text-scale compensation
             // is active (force-device-scale-factor was set).  Otherwise

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -521,43 +521,14 @@ pub fn run() {
                 }
             });
 
-            // 6. Backend ping loop — pings all active sessions every 60 seconds.
-            let ping_app = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                // Wait for at least one session to exist
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                    if let Some(state) = ping_app.try_state::<AppState>() {
-                        if !state.sessions.read().await.is_empty() {
-                            break;
-                        }
-                    }
-                }
-                tracing::info!("backend ping loop started");
-
-                let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-                loop {
-                    interval.tick().await;
-                    if let Some(state) = ping_app.try_state::<AppState>() {
-                        let sessions = state.sessions.read().await;
-                        if sessions.is_empty() {
-                            tracing::info!("backend ping loop stopped (no sessions)");
-                            break;
-                        }
-                        for ss in sessions.values() {
-                            let region = {
-                                let session = ss.session.read().await;
-                                session.as_ref().map(|s| s.region.clone())
-                            };
-                            if let Some(region) = region {
-                                if let Ok(_guard) = ss.bf_client_lock.try_lock() {
-                                    services::beanfun_service::ping(&ss.http_client, &region).await;
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+            // 6. Session keep-alive is handled by the frontend (MainPage pings
+            //    ONLY the active session every 60s). We deliberately do NOT run a
+            //    backend loop that pings *every* session: keep-aliving all logged-in
+            //    accounts at once is a signal 3-4 separate browsers never produce,
+            //    and it made beanfun drop the inactive sessions when several
+            //    accounts were logged in ("login 3, only 1 survives"). Inactive
+            //    beanfun sessions stay valid for a long time on their own, just
+            //    like a background browser tab, so no background ping is needed.
 
             // Only resize the initial window when text-scale compensation
             // is active (force-device-scale-factor was set).  Otherwise

--- a/src-tauri/src/models/session_state.rs
+++ b/src-tauri/src/models/session_state.rs
@@ -8,9 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::header::{
-    HeaderMap, HeaderName, HeaderValue, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT,
-};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, USER_AGENT};
 use tokio::sync::{Mutex, RwLock};
 
 use super::game_account::GameAccount;
@@ -59,35 +57,20 @@ impl SessionState {
     /// Create a new session state with a fresh HTTP client and cookie jar.
     pub fn new() -> Self {
         let cookie_jar = Arc::new(reqwest::cookie::Jar::default());
-        // Match a current Chrome browser: beanfun's bot-risk scoring flags stale
-        // UAs / missing client hints, which was tripping the ~5-min IP lock even
-        // when a real person solved the reCAPTCHA. These headers are constant for
-        // a browser, so they're safe as client-wide defaults; per-request
-        // Sec-Fetch-* metadata is added on the login XHR calls in beanfun_service.
+        // NOTE: keep this the plain legacy UA with NO client hints. beanfun's
+        // *modern* code path (served to Chrome-149-looking clients) enforces
+        // stricter per-fingerprint session rules that a non-browser can't satisfy
+        // for more than one concurrent account — which broke multi-account login.
+        // The modern UA + sec-ch-ua that the TW reCAPTCHA login needs are added
+        // ONLY on those two login POSTs in beanfun_service (see `BROWSER_UA` /
+        // `with_browser_xhr_headers`), so everything else stays on the lenient
+        // legacy path that supports several sessions at once.
         let mut default_headers = HeaderMap::new();
         default_headers.insert(
             USER_AGENT,
             HeaderValue::from_static(
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
+                "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36",
             ),
-        );
-        default_headers.insert(
-            HeaderName::from_static("sec-ch-ua"),
-            HeaderValue::from_static(
-                "\"Google Chrome\";v=\"149\", \"Chromium\";v=\"149\", \"Not)A;Brand\";v=\"24\"",
-            ),
-        );
-        default_headers.insert(
-            HeaderName::from_static("sec-ch-ua-mobile"),
-            HeaderValue::from_static("?0"),
-        );
-        default_headers.insert(
-            HeaderName::from_static("sec-ch-ua-platform"),
-            HeaderValue::from_static("\"Windows\""),
-        );
-        default_headers.insert(
-            ACCEPT_LANGUAGE,
-            HeaderValue::from_static("zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7"),
         );
         default_headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
         let http_client = reqwest::Client::builder()

--- a/src-tauri/src/services/beanfun_service.rs
+++ b/src-tauri/src/services/beanfun_service.rs
@@ -17,13 +17,19 @@ use crate::models::game_account::{GameAccount, GameCredentials};
 use crate::models::session::{Region, Session, TotpState};
 use crate::utils::crypto::des_ecb_decrypt_hex;
 
-/// User-Agent matching a current Chrome browser. beanfun's bot-risk scoring
-/// flags stale UAs (the old Chrome/55 string tripped the ~5-min IP lock even
-/// after a human solved the reCAPTCHA), so this is kept in sync with the
-/// `sec-ch-ua` version below and the session client defaults.
-const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
+/// Default User-Agent for all beanfun requests — the plain LEGACY Chrome string.
+///
+/// IMPORTANT: keep this the old UA. A modern Chrome UA opts every request into
+/// beanfun's stricter per-fingerprint session handling, which a non-browser
+/// can't satisfy for several concurrent accounts (it broke multi-account login).
+/// Only the TW reCAPTCHA login POSTs use [`BROWSER_UA`] + `sec-ch-ua`, which is
+/// what that specific flow needs to avoid the bot-risk IP lock.
+const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36";
 
-/// Chrome client-hint brand string; the version must match [`USER_AGENT`].
+/// Modern Chrome UA used ONLY on the TW login POSTs (paired with [`SEC_CH_UA`]).
+const BROWSER_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
+
+/// Chrome client-hint brand string; the version must match [`BROWSER_UA`].
 const SEC_CH_UA: &str =
     "\"Google Chrome\";v=\"149\", \"Chromium\";v=\"149\", \"Not)A;Brand\";v=\"24\"";
 
@@ -1331,7 +1337,7 @@ async fn tw_check_account_type(
     let check_resp = with_browser_xhr_headers(
         client
             .post(&check_url)
-            .header("User-Agent", USER_AGENT)
+            .header("User-Agent", BROWSER_UA)
             .header("Content-Type", "application/json; charset=utf-8")
             .header("X-Requested-With", "XMLHttpRequest")
             .header("RequestVerificationToken", form_token)
@@ -1383,11 +1389,12 @@ fn is_blank(token: Option<&str>) -> bool {
     token.map(|t| t.trim().is_empty()).unwrap_or(true)
 }
 
-/// Add the `Accept` + `Sec-Fetch-*` + client-hint headers a real browser sends
-/// on a same-origin `fetch`/XHR. Combined with the session client's UA +
-/// `sec-ch-ua` defaults, this makes our login POSTs look like the website —
-/// without it, beanfun's bot-risk scoring tripped the ~5-min IP lock even after
-/// a human solved the reCAPTCHA.
+/// Add the `Accept` + `Sec-Fetch-*` + `sec-ch-ua` headers a real browser sends
+/// on a same-origin `fetch`/XHR. Paired with [`BROWSER_UA`] on the two TW login
+/// POSTs, this makes them look like the website — without it, beanfun's bot-risk
+/// scoring tripped the ~5-min IP lock even after a human solved the reCAPTCHA.
+/// These modern-browser headers are deliberately scoped to just those POSTs so
+/// every other request stays on the legacy UA (see [`USER_AGENT`]).
 fn with_browser_xhr_headers(rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
     rb.header("Accept", "application/json, text/plain, */*")
         .header("sec-ch-ua", SEC_CH_UA)
@@ -1454,7 +1461,7 @@ async fn tw_account_login(
     let login_resp = with_browser_xhr_headers(
         client
             .post(&login_url)
-            .header("User-Agent", USER_AGENT)
+            .header("User-Agent", BROWSER_UA)
             .header("Content-Type", "application/json; charset=utf-8")
             .header("X-Requested-With", "XMLHttpRequest")
             .header("RequestVerificationToken", form_token)

--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -18,7 +18,7 @@
         "width": 350,
         "height": 620,
         "decorations": false,
-        "transparent": false,
+        "transparent": true,
         "resizable": false,
         "shadow": true,
         "center": true,

--- a/src/features/launcher/AccountContextMenu.tsx
+++ b/src/features/launcher/AccountContextMenu.tsx
@@ -423,7 +423,7 @@ export function AccountContextMenu({ position, account, onClose }: AccountContex
   }
 
   function handleSupport() {
-    commands.openCustomerService().catch(() => {});
+    commands.openCustomerService(useAuthStore.getState().activeSessionId ?? "").catch(() => {});
     onClose();
   }
 

--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -33,18 +33,6 @@ export function MainPage() {
   const latestOtpRef = useRef<{ accountId: string; otp: string } | null>(null);
   const { data: accounts } = useGameAccounts();
 
-  // Reset the selection whenever the active session (account tab) changes —
-  // otherwise a stale selectedAccountId from another session gets fetched
-  // against the newly-active session ("account not found" → wrong session
-  // logged out). Done during render (React's "reset state on prop change"
-  // pattern) so the auto-select below immediately picks THIS session's account.
-  const [prevSessionId, setPrevSessionId] = useState(activeSessionId);
-  if (activeSessionId !== prevSessionId) {
-    setPrevSessionId(activeSessionId);
-    setSelectedAccountId(null);
-    setAutoSelected(false);
-  }
-
   // Auto-select first account when accounts load and nothing is selected.
   if (!autoSelected && accounts?.length && !selectedAccountId) {
     const first = accounts[0];
@@ -167,7 +155,9 @@ export function MainPage() {
       setSelectedAccountId(accountId);
       setLaunching(true);
       try {
-        const processId = await commands.launchGame(activeSessionId ?? "", accountId, otp);
+        // Launch with the session that OWNS this account (not the global active).
+        const sessionId = useAuthStore.getState().sessionIdForAccount(accountId) ?? "";
+        const processId = await commands.launchGame(sessionId, accountId, otp);
         if (processId > 0) {
           setGamePid(processId);
           setGameRunning(true);
@@ -176,7 +166,7 @@ export function MainPage() {
         setLaunching(false);
       }
     },
-    [activeSessionId, setGamePid, setGameRunning],
+    [setGamePid, setGameRunning],
   );
 
   async function handlePlayClick() {

--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -607,7 +607,9 @@ function MorePopupMenu({
       </button>
       <button
         onClick={() => {
-          commands.openCustomerService().catch(() => {});
+          commands
+            .openCustomerService(useAuthStore.getState().activeSessionId ?? "")
+            .catch(() => {});
           onClose();
         }}
         className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[12px] text-[var(--text)] transition-colors hover:bg-[rgba(232,162,58,0.08)] hover:text-accent"

--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -370,7 +370,7 @@ export function MainPage() {
               {beansMenuOpen && (
                 <BeansPopupMenu
                   t={t}
-                  region={region}
+                  region={session?.region ?? region}
                   onRefresh={async () => {
                     const pts = await commands.getRemainPoint(activeSessionId ?? "");
                     setRemainPoint(pts);

--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -33,6 +33,18 @@ export function MainPage() {
   const latestOtpRef = useRef<{ accountId: string; otp: string } | null>(null);
   const { data: accounts } = useGameAccounts();
 
+  // Reset the selection whenever the active session (account tab) changes —
+  // otherwise a stale selectedAccountId from another session gets fetched
+  // against the newly-active session ("account not found" → wrong session
+  // logged out). Done during render (React's "reset state on prop change"
+  // pattern) so the auto-select below immediately picks THIS session's account.
+  const [prevSessionId, setPrevSessionId] = useState(activeSessionId);
+  if (activeSessionId !== prevSessionId) {
+    setPrevSessionId(activeSessionId);
+    setSelectedAccountId(null);
+    setAutoSelected(false);
+  }
+
   // Auto-select first account when accounts load and nothing is selected.
   if (!autoSelected && accounts?.length && !selectedAccountId) {
     const first = accounts[0];

--- a/src/features/launcher/OtpPanel.tsx
+++ b/src/features/launcher/OtpPanel.tsx
@@ -22,12 +22,13 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
 
   function handleOtpError(error: Error) {
     const msg = error.message || t("launcher.otp_error");
+    // Only these clearly mean the session itself is dead. Do NOT include the
+    // generic "Invalid credentials" — it also covers "account … not found",
+    // which is a session/account mismatch (e.g. a stale selected account fetched
+    // against another logged-in session), and treating that as a dead session
+    // wrongly logged the WRONG account out ("斷曬" with multiple accounts).
     const isSessionGone =
-      msg.includes("Not authenticated") ||
-      msg.includes("expired") ||
-      msg.includes("閒置過久") ||
-      msg.includes("重新登入") ||
-      msg.includes("Invalid credentials");
+      msg.includes("Not authenticated") || msg.includes("閒置過久") || msg.includes("重新登入");
 
     if (isSessionGone) {
       // Session is dead — remove it and redirect to login

--- a/src/features/launcher/OtpPanel.tsx
+++ b/src/features/launcher/OtpPanel.tsx
@@ -22,13 +22,12 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
 
   function handleOtpError(error: Error) {
     const msg = error.message || t("launcher.otp_error");
-    // Only these clearly mean the session itself is dead. Do NOT include the
-    // generic "Invalid credentials" — it also covers "account … not found",
-    // which is a session/account mismatch (e.g. a stale selected account fetched
-    // against another logged-in session), and treating that as a dead session
-    // wrongly logged the WRONG account out ("斷曬" with multiple accounts).
     const isSessionGone =
-      msg.includes("Not authenticated") || msg.includes("閒置過久") || msg.includes("重新登入");
+      msg.includes("Not authenticated") ||
+      msg.includes("expired") ||
+      msg.includes("閒置過久") ||
+      msg.includes("重新登入") ||
+      msg.includes("Invalid credentials");
 
     if (isSessionGone) {
       // Session is dead — remove it and redirect to login
@@ -55,7 +54,7 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
       setPasting(true);
       try {
         const pasted = await commands.autoPasteOtp(
-          useAuthStore.getState().activeSessionId ?? "",
+          useAuthStore.getState().sessionIdForAccount(selectedAccountId) ?? "",
           selectedAccountId,
         );
         // Always fetch credentials to display OTP regardless of paste result

--- a/src/lib/hooks/use-accounts.ts
+++ b/src/lib/hooks/use-accounts.ts
@@ -24,7 +24,10 @@ export function useGameAccounts() {
 export function useGameCredentials() {
   return useMutation<GameCredentialsDto, Error, string>({
     mutationFn: (accountId: string) => {
-      const sessionId = useAuthStore.getState().activeSessionId ?? "";
+      // Use the session that OWNS this account, not the globally-active one —
+      // otherwise switching account tabs fetches an account against the wrong
+      // session ("account not found" → the wrong account gets logged out).
+      const sessionId = useAuthStore.getState().sessionIdForAccount(accountId) ?? "";
       return commands.getGameCredentials(sessionId, accountId);
     },
   });

--- a/src/lib/stores/auth-store.ts
+++ b/src/lib/stores/auth-store.ts
@@ -29,6 +29,8 @@ export interface AuthState {
   getActiveSession: () => SessionEntry | null;
   getActiveSessionId: () => string | null;
   getActiveGameAccounts: () => GameAccountDto[];
+  /** The session that owns a given game account (falls back to active). */
+  sessionIdForAccount: (accountId: string) => string | null;
 
   // Actions
   addSession: (session: SessionDto, gameAccounts?: GameAccountDto[]) => void;
@@ -83,6 +85,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   getActiveGameAccounts: () => {
     const entry = get().getActiveSession();
     return entry?.gameAccounts ?? [];
+  },
+
+  sessionIdForAccount: (accountId) => {
+    for (const [sid, entry] of get().sessions) {
+      if (entry.gameAccounts.some((a) => a.id === accountId)) return sid;
+    }
+    // Unknown account (not in any loaded list) — fall back to the active one.
+    return get().activeSessionId;
   },
 
   addSession: (session, gameAccounts = []) => {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -136,7 +136,7 @@ export const commands = {
   // Beanfun points (session-specific)
   openGashPopup: (sessionId: string) => invoke("open_gash_popup", { sessionId }),
   openMemberPopup: (sessionId: string) => invoke("open_member_popup", { sessionId }),
-  openCustomerService: () => invoke("open_customer_service"),
+  openCustomerService: (sessionId: string) => invoke("open_customer_service", { sessionId }),
   openAuthPopup: (sessionId: string, url: string, title: string) =>
     invoke("open_auth_popup", { sessionId, url, title }),
   pingSession: (sessionId: string) => invoke<boolean>("ping_session", { sessionId }),


### PR DESCRIPTION
## What
Fixes several multi-account (especially mixed HK + TW) bugs where per-account actions were routed to the wrong session or region, plus a window-appearance fix.

- **Account dropping ("disconnected").** OTP / auto-paste / launch used the global `activeSessionId`, so after switching account tabs a selected account was fetched against the wrong session → beanfun `account not found` → the wrong account got logged out (cascading to the others). New `auth-store` selector `sessionIdForAccount(accountId)` resolves the session that actually owns the account; `useGameCredentials`, OTP auto-paste and launch use it.
- **Fake logout on points/top-up/exchange/member/support.** Those popups built the beanfun host from the global `config.region` toggle (HK) while seeding the active TW session's cookies → an HK logged-out page. `open_gash_popup`, `open_member_popup`, `open_customer_service` and `change_display_name` now use the **session's** region.
- **"兌換樂豆點" (TW-only) leaking onto HK accounts.** Gated by the session's region instead of the global toggle.
- **Modern UA scoped to TW login only.** The earlier reCAPTCHA IP-lock fix set a Chrome/149 UA + client-hints as global defaults, which opted every session into beanfun's stricter single-fingerprint path and broke multi-account. The legacy UA is restored everywhere; the modern UA + `sec-ch-ua` stay only on the two TW login POSTs that need it.
- **Window black corners/border.** The borderless window was opaque while the body has a border-radius, so the corners painted black. Window is now transparent (CSS rounding defines the edge) with DWM corner = round.

## Why
The launcher UI is byte-identical to 0.3.6, so these were latent global-state bugs (`activeSessionId` / `config.region` used for per-account actions) that only surface with several accounts across regions — not a UI regression. The global modern-UA change was the one true regression, reverted here.

## How to test
1. Log in 2-3 accounts across **HK and TW**; fetch OTP / launch from each tab → no disconnects, no fake logouts.
2. On a TW account, open 更新點數 / 儲值 / 兌換 / 會員中心 / 客服 → all show TW pages (not a logged-out HK page). On an HK account, 兌換樂豆點 is hidden.
3. TW reCAPTCHA login still works with no IP-lock.
4. Window has no black corners / black border.

## Checklist
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm run lint`
- [x] `npx prettier --check "src/**/*.{ts,tsx,css,json}"`
- [x] `npx tsc -b`