### PR TITLE
feat(privacy): hide account names toggle (blur, reveal on hover)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maplelink"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -198,6 +198,9 @@ fn apply_config_field(config: &mut AppConfig, key: &str, value: &str) -> Result<
                 }
             };
         }
+        "hideAccountNames" | "hide_account_names" => {
+            config.hide_account_names = parse_bool(value)?;
+        }
         "__reset__" => {
             *config = AppConfig::default();
         }

--- a/src-tauri/src/core/config_parser.rs
+++ b/src-tauri/src/core/config_parser.rs
@@ -97,6 +97,10 @@ pub fn parse_ini(input: &str) -> Result<AppConfig, ConfigError> {
         if let Some(v) = general.get("close_behavior") {
             config.close_behavior = parse_close_behavior(v);
         }
+        if let Some(v) = general.get("hide_account_names") {
+            config.hide_account_names =
+                parse_bool(v, "hide_account_names", defaults.hide_account_names);
+        }
     }
 
     // --- [game] ---
@@ -188,6 +192,10 @@ pub fn serialize_ini(config: &AppConfig) -> String {
     out.push_str(&format!(
         "close_behavior = {}\n",
         close_behavior_to_str(&config.close_behavior)
+    ));
+    out.push_str(&format!(
+        "hide_account_names = {}\n",
+        config.hide_account_names
     ));
     out.push('\n');
 
@@ -511,6 +519,7 @@ x = not_a_number
             web_launch_auto_launch: false,
             web_launch_auto_paste: true,
             close_behavior: crate::models::config::CloseBehavior::Tray,
+            hide_account_names: true,
         };
         let ini = serialize_ini(&original);
         let parsed = parse_ini(&ini).unwrap();

--- a/src-tauri/src/core/game_launcher.rs
+++ b/src-tauri/src/core/game_launcher.rs
@@ -261,6 +261,7 @@ mod tests {
                         web_launch_auto_launch: true,
                         web_launch_auto_paste: true,
                         close_behavior: crate::models::config::CloseBehavior::Ask,
+                        hide_account_names: false,
                     }
                 },
             )

--- a/src-tauri/src/models/config.rs
+++ b/src-tauri/src/models/config.rs
@@ -53,6 +53,10 @@ pub struct AppConfig {
     /// What to do when the window is closed (default: ask each time).
     #[serde(default)]
     pub close_behavior: CloseBehavior,
+    /// Blur game-account / session names in the UI so they aren't leaked in
+    /// screenshots (revealed on hover). Default: false.
+    #[serde(default)]
+    pub hide_account_names: bool,
 }
 
 fn default_true() -> bool {
@@ -90,6 +94,7 @@ impl Default for AppConfig {
             web_launch_auto_launch: true,
             web_launch_auto_paste: true,
             close_behavior: CloseBehavior::Ask,
+            hide_account_names: false,
         }
     }
 }

--- a/src-tauri/tests/config_roundtrip.rs
+++ b/src-tauri/tests/config_roundtrip.rs
@@ -110,6 +110,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 web_launch_auto_launch: true,
                 web_launch_auto_paste: true,
                 close_behavior: maplelink_lib::models::config::CloseBehavior::Tray,
+                hide_account_names: true,
             }
         },
     )

--- a/src-tauri/tests/no_credentials_on_disk.rs
+++ b/src-tauri/tests/no_credentials_on_disk.rs
@@ -117,6 +117,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 web_launch_auto_launch: true,
                 web_launch_auto_paste: true,
                 close_behavior: maplelink_lib::models::config::CloseBehavior::Ask,
+                hide_account_names: false,
             }
         },
     )

--- a/src/features/launcher/AccountGrid.tsx
+++ b/src/features/launcher/AccountGrid.tsx
@@ -7,6 +7,10 @@ import { commands } from "../../lib/tauri";
 import { AccountContextMenu } from "./AccountContextMenu";
 import type { GameAccountDto } from "../../lib/types";
 
+/** Applied to account name/id text when the "hide account names" privacy
+ *  setting is on: blurred by default, revealed on hover. */
+const MASK_CLASS = "blur-[5px] transition-[filter] duration-150 select-none hover:blur-none";
+
 interface AccountGridProps {
   selectedAccountId: string | null;
   onSelectAccount: (account: GameAccountDto) => void;
@@ -257,6 +261,7 @@ function CardItem({
   copyTitle: string;
 }) {
   const initial = account.displayName.charAt(0).toUpperCase();
+  const mask = useConfigStore((s) => (s.config?.hideAccountNames ? MASK_CLASS : ""));
   return (
     <button
       data-acct-idx={idx}
@@ -298,8 +303,10 @@ function CardItem({
       >
         {initial}
       </div>
-      <span className="truncate text-xs font-medium text-[var(--text)]">{account.displayName}</span>
-      <span className="truncate font-mono text-[12px] text-text-faint">{account.id}</span>
+      <span className={`truncate text-xs font-medium text-[var(--text)] ${mask}`}>
+        {account.displayName}
+      </span>
+      <span className={`truncate font-mono text-[12px] text-text-faint ${mask}`}>{account.id}</span>
     </button>
   );
 }
@@ -331,6 +338,7 @@ function ListItem({
   copyTitle: string;
 }) {
   const initial = account.displayName.charAt(0).toUpperCase();
+  const mask = useConfigStore((s) => (s.config?.hideAccountNames ? MASK_CLASS : ""));
   return (
     <button
       data-acct-idx={idx}
@@ -367,8 +375,10 @@ function ListItem({
         {initial}
       </div>
       <div className="min-w-0 flex-1">
-        <div className="truncate text-xs font-medium text-[var(--text)]">{account.displayName}</div>
-        <div className="truncate font-mono text-[11px] text-text-faint">{account.id}</div>
+        <div className={`truncate text-xs font-medium text-[var(--text)] ${mask}`}>
+          {account.displayName}
+        </div>
+        <div className={`truncate font-mono text-[11px] text-text-faint ${mask}`}>{account.id}</div>
       </div>
       <CopyIcon isCopied={isCopied} onClick={onCopy} title={copyTitle} position="" />
     </button>

--- a/src/features/launcher/AccountGrid.tsx
+++ b/src/features/launcher/AccountGrid.tsx
@@ -306,7 +306,6 @@ function CardItem({
       <span className={`truncate text-xs font-medium text-[var(--text)] ${mask}`}>
         {account.displayName}
       </span>
-      <span className={`truncate font-mono text-[12px] text-text-faint ${mask}`}>{account.id}</span>
     </button>
   );
 }
@@ -378,7 +377,6 @@ function ListItem({
         <div className={`truncate text-xs font-medium text-[var(--text)] ${mask}`}>
           {account.displayName}
         </div>
-        <div className={`truncate font-mono text-[11px] text-text-faint ${mask}`}>{account.id}</div>
       </div>
       <CopyIcon isCopied={isCopied} onClick={onCopy} title={copyTitle} position="" />
     </button>

--- a/src/features/launcher/SessionTabs.tsx
+++ b/src/features/launcher/SessionTabs.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react";
 import { useTranslation } from "../../lib/i18n";
 import { useAuthStore, type SessionEntry } from "../../lib/stores/auth-store";
 import { useUiStore } from "../../lib/stores/ui-store";
+import { useConfigStore } from "../../lib/stores/config-store";
 import { commands } from "../../lib/tauri";
 
 export function SessionTabs() {
@@ -11,6 +12,11 @@ export function SessionTabs() {
   const setActiveSessionId = useAuthStore((s) => s.setActiveSessionId);
   const removeSession = useAuthStore((s) => s.removeSession);
   const setPage = useUiStore((s) => s.setPage);
+  const mask = useConfigStore((s) =>
+    s.config?.hideAccountNames
+      ? "blur-[5px] transition-[filter] duration-150 select-none hover:blur-none"
+      : "",
+  );
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -160,7 +166,7 @@ export function SessionTabs() {
                 autoFocus
               />
             ) : (
-              <span className="max-w-[100px] truncate">{entry.session.accountName}</span>
+              <span className={`max-w-[100px] truncate ${mask}`}>{entry.session.accountName}</span>
             )}
             <span className="text-[9px] text-text-faint">{entry.session.region}</span>
             {!isEditing && (

--- a/src/features/toolbox/AdvancedTab.tsx
+++ b/src/features/toolbox/AdvancedTab.tsx
@@ -110,6 +110,23 @@ export function AdvancedTab() {
         {t("settings.traditional_login_desc")}
       </p>
 
+      {/* Hide account names (privacy) */}
+      <SettingRow label={t("settings.hide_account_names")}>
+        <Toggle
+          checked={config?.hideAccountNames ?? false}
+          onChange={() => {
+            if (!config) return;
+            setConfig.mutate({
+              key: "hide_account_names",
+              value: String(!config.hideAccountNames),
+            });
+          }}
+        />
+      </SettingRow>
+      <p className="px-1 text-[11px] leading-relaxed text-text-faint">
+        {t("settings.hide_account_names_desc")}
+      </p>
+
       {/* Window close behaviour */}
       <SettingRow label={t("settings.close_behavior")}>
         <Dropdown

--- a/src/lib/hooks/use-config.ts
+++ b/src/lib/hooks/use-config.ts
@@ -49,6 +49,7 @@ const KEY_MAP: Record<string, string> = {
   webLaunchAutoLaunch: "web_launch_auto_launch",
   webLaunchAutoPaste: "web_launch_auto_paste",
   closeBehavior: "close_behavior",
+  hideAccountNames: "hide_account_names",
   __reset__: "__reset__",
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,7 @@ export interface AppConfigDto {
   webLaunchAutoLaunch: boolean;
   webLaunchAutoPaste: boolean;
   closeBehavior: "ask" | "quit" | "tray";
+  hideAccountNames: boolean;
 }
 
 export interface ErrorDto {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -97,6 +97,8 @@
   "settings.skip_play_confirm_desc": "Auto-close the game's Play button window and skip relaunch confirmation",
   "settings.traditional_login": "Traditional Login Mode",
   "settings.traditional_login_desc": "Launch the game without passing server connection args. Disable this to pass server/port/account/OTP directly to the game.",
+  "settings.hide_account_names": "Hide account names",
+  "settings.hide_account_names_desc": "Blur account names / IDs in the account list and tabs so they aren't leaked in screenshots (hover to reveal).",
   "settings.close_behavior": "On window close",
   "settings.close_behavior_desc": "What happens when you close the window; “Ask every time” shows a prompt on close.",
   "settings.close_ask": "Ask every time",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -97,6 +97,8 @@
   "settings.skip_play_confirm_desc": "自动关闭游戏的 Play 按钮窗口，并跳过重启确认",
   "settings.traditional_login": "传统模式登录",
   "settings.traditional_login_desc": "启动游戏时不传送服务器连接参数。关闭此选项会将服务器/端口/账号/OTP 直接传给游戏。",
+  "settings.hide_account_names": "隐藏账号名称",
+  "settings.hide_account_names_desc": "将账号列表与分页的名称／编号模糊处理，避免截图时泄露（鼠标移上去可临时显示）。",
   "settings.close_behavior": "关闭窗口时",
   "settings.close_behavior_desc": "设定按下关闭时的行为；选「每次询问」会在关闭时弹出选项。",
   "settings.close_ask": "每次询问",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -97,6 +97,8 @@
   "settings.skip_play_confirm_desc": "自動關閉遊戲的 Play 按鈕視窗，並跳過重啟確認",
   "settings.traditional_login": "傳統模式登入",
   "settings.traditional_login_desc": "啟動遊戲時不傳送伺服器連線參數。關閉此選項會將伺服器/連接埠/帳號/OTP 直接傳給遊戲。",
+  "settings.hide_account_names": "隱藏帳號名稱",
+  "settings.hide_account_names_desc": "將帳號列表與分頁的名稱／編號模糊處理，避免截圖時外洩（滑鼠移上去可暫時顯示）。",
   "settings.close_behavior": "關閉視窗時",
   "settings.close_behavior_desc": "設定按下關閉時的行為；選「每次詢問」會在關閉時彈出選項。",
   "settings.close_ask": "每次詢問",


### PR DESCRIPTION
## What
A **Hide account names** privacy toggle (Advanced settings). When on, account names/IDs are **blurred** in the UI and **revealed on hover**.

Applies to:
- The game-account list (both card and list views) — the account **name** and **id** (`T9…`).
- The multi-account **session tabs** — the account name.

## Why
User feedback: the game-account list (and the multi-account tab list) show account names/IDs directly, which can be **leaked when sharing screenshots**. Rather than removing the display (users still need to identify their own accounts), this masks it so it's safe by default in screenshots but still usable via hover.

## How
- New `hide_account_names` config (bool, default **off**, `[general]` in config.ini) — wired through the parser, `set_config`, and the DTO.
- A CSS blur (`blur-[5px] … hover:blur-none`) applied to the name/id spans when the setting is on.
- Advanced settings toggle + i18n (zh-TW / en-US / zh-CN).

## How to test
1. Advanced settings → **Hide account names** = on.
2. Account list + session tabs: names/IDs are blurred; hovering a name reveals it.
3. Toggle off → shown normally. Confirm `hide_account_names` persists in config.ini.

## Note
Default is **off** (unchanged behaviour for existing users). Say the word if you'd rather default it **on** for safety.

## Checklist
- [x] cargo clippy --all-targets -D warnings, cargo fmt, cargo test
- [x] tsc / eslint, i18n in all three locales