### PR TITLE
fix(recaptcha): reveal the real page instead of spinning on slow connections

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -2187,40 +2187,48 @@ const RECAPTCHA_INIT_SCRIPT: &str = r#"
     //     page (or, once the reload budget is spent, close so the frontend isn't
     //     stuck on a blank helper — closing fires `recaptcha-cancelled`).
     let placed = false;
+    // Reveal the real reCAPTCHA page (remove the opaque overlay). This is the
+    // graceful fallback for slow accelerator/VPN connections where the widget
+    // loads late or our selectors miss it: the user is NEVER left stuck on a
+    // spinner, and never depends on an IPC close that beanfun's CSP can block —
+    // they just solve the reCAPTCHA on the visible page (the token harvest below
+    // still works). Less pretty than the reparent, but always usable.
+    const reveal = () => {
+      if (placed) return;
+      placed = true; clearInterval(rt);
+      try { if (store) store.removeItem(RKEY); } catch (e) {}
+      ov.remove();
+    };
     const place = () => {
       if (placed) return;
       const w = findWidget();
       if (w && w !== document.body && w !== document.documentElement) {
         placed = true; clearInterval(rt);
+        try { if (store) store.removeItem(RKEY); } catch (e) {}
         w.style.position = 'relative';
         w.style.zIndex = String(OVERLAY_Z + 2);
         sp.remove();
         lb.textContent = '請完成「我不是機器人」驗證';
         ov.appendChild(w); // reparent → iframe reload → fresh checkbox
-        return;
-      }
-      // Safety-net path (no widget yet). Only give up once the reload has run.
-      if (store && store.getItem(RKEY)) {
-        placed = true; clearInterval(rt);
-        try { store.removeItem(RKEY); } catch (e) {}
-        console.warn('[reCAPTCHA] widget did not render (reload budget spent) — closing');
-        if (window.__TAURI_INTERNALS__) {
-          window.__TAURI_INTERNALS__.invoke('close_recaptcha_window').catch(() => {});
-        }
       }
     };
     const rt = setInterval(() => { if (anchor()) place(); }, 200);
-    setTimeout(place, 6000); // safety net so the spinner never sticks forever
 
-    // (3b) Self-heal beanfun's first-load render race: no reCAPTCHA iframe after
-    //      3.5s → reload once (guarded so it can't loop).
+    // (3b) Self-heal beanfun's first-load render race: ONLY if there is no
+    //      reCAPTCHA iframe at all after 4s (genuine render fail), reload once.
+    //      Slow connections keep the iframe present, so they skip this and just
+    //      wait for the widget → they don't get a disruptive reload.
     setTimeout(() => {
-      if (!document.querySelector("iframe[src*='recaptcha']") && store && !store.getItem(RKEY)) {
+      if (!placed && !document.querySelector("iframe[src*='recaptcha']") && store && !store.getItem(RKEY)) {
         store.setItem(RKEY, '1');
-        console.warn('[reCAPTCHA] widget did not render — reloading once');
+        console.warn('[reCAPTCHA] no widget — reloading once');
         location.reload();
       }
-    }, 3500);
+    }, 4000);
+
+    // Final fallback: if the widget still isn't reparented, reveal the real page
+    // rather than hide it behind the spinner forever.
+    setTimeout(reveal, 6500);
 
     // (4) Harvest the Enterprise token once the human ticks the checkbox.
     //     Primary source is grecaptcha.enterprise.getResponse() — beanfun is an


### PR DESCRIPTION
## What
Fixes the reCAPTCHA helper window spinning forever ("驗證載入中，請稍候…") for users on **accelerators / VPNs**.

## Why
The reparent flow lays an **opaque overlay + spinner** and only removes it once it has detected and reparented the reCAPTCHA widget. On a slow accelerator/VPN, `www.google.com` reCAPTCHA loads late (or our selectors miss it), so:
- the working reCAPTCHA stays **hidden behind the spinner**, and
- the give-up path called `close_recaptcha_window` over **IPC, which beanfun's page CSP can block** — so the window just span until the 180s frontend timeout. Users had to close it manually.

(The old z-index-mask method was less pretty but never hid the page, so it "worked".)

## How
- The overlay is now a **graceful loading skin**: if the widget isn't reparented within ~6.5s, it **reveals the real reCAPTCHA page** (removes itself) so the user can solve it directly. Never a stuck spinner, never dependent on an IPC close.
- The self-heal reload now only fires when there's **genuinely no reCAPTCHA iframe** (a real render race). A merely slow-loading widget keeps the iframe present, so slow connections skip the disruptive reload and just wait for the widget.
- The token harvest (`grecaptcha.getResponse()` → `#mltoken` fragment) is unchanged and works whether the widget was reparented or revealed.

## How to test
1. Normal connection: reCAPTCHA still shows in the overlay (reparented) and solves as before.
2. On an accelerator/VPN (or throttled): the window no longer spins forever — after a few seconds the real reCAPTCHA page appears and can be solved; login completes.

## Checklist
- [x] cargo clippy -D warnings, cargo fmt
- [ ] Needs verification on an accelerator/VPN connection (reporter)