### PR TITLE
fix: open external links unelevated via the desktop shell

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -581,6 +581,21 @@ pub async fn detect_game_path(
     game_env_service::detect_game_path(&state).await
 }
 
+/// Open an external web link in the user's browser, unelevated.
+///
+/// MapleLink runs elevated, so anything it spawns inherits the admin token — a
+/// browser started that way corrupts the user's real profile. This routes the
+/// link through the desktop shell instead. Rejects non-http(s) targets.
+#[tauri::command]
+pub async fn open_external(url: String) -> Result<(), ErrorDto> {
+    crate::utils::shell_open::open_external_url(&url).map_err(|e| ErrorDto {
+        code: "SYS_OPEN_URL_FAILED".to_string(),
+        message: e,
+        category: ErrorCategory::Process,
+        details: Some(url),
+    })
+}
+
 /// Open the app's log directory in the system file explorer.
 #[tauri::command]
 pub async fn open_log_folder(app: tauri::AppHandle) -> Result<(), ErrorDto> {
@@ -591,7 +606,7 @@ pub async fn open_log_folder(app: tauri::AppHandle) -> Result<(), ErrorDto> {
         details: None,
     })?;
 
-    open::that(&log_dir).map_err(|e| ErrorDto {
+    crate::utils::shell_open::shell_open(&log_dir.to_string_lossy()).map_err(|e| ErrorDto {
         code: "SYS_OPEN_FOLDER_FAILED".to_string(),
         message: format!("Failed to open folder: {e}"),
         category: ErrorCategory::Process,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -321,6 +321,7 @@ pub fn run() {
             commands::system::detect_game_path,
             commands::system::toggle_debug_window,
             commands::system::open_log_folder,
+            commands::system::open_external,
             commands::system::get_recent_logs,
             commands::system::open_web_popup,
             commands::system::open_gash_popup,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -390,6 +390,10 @@ pub fn run() {
                 }
             }
             tracing::info!("log directory: {}", log_dir.display());
+            // Elevated means every process we spawn inherits the admin token —
+            // external links must go through the shell, never straight from us.
+            #[cfg(target_os = "windows")]
+            tracing::info!("running elevated: {}", is_elevated());
 
             // 2. Load config from disk (create default if missing).
             let config_dir = app

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod crypto;
 pub mod dpapi;
+pub mod shell_open;

--- a/src-tauri/src/utils/shell_open.rs
+++ b/src-tauri/src/utils/shell_open.rs
@@ -21,16 +21,28 @@
 #[cfg(target_os = "windows")]
 pub fn shell_open(target: &str) -> Result<(), String> {
     use std::os::windows::process::CommandExt;
-    std::process::Command::new("explorer.exe")
+    match std::process::Command::new("explorer.exe")
         .arg(target)
         .creation_flags(0x0800_0000) // CREATE_NO_WINDOW
         .spawn()
-        .map(|_| ())
-        .map_err(|e| format!("failed to launch explorer.exe: {e}"))
+    {
+        Ok(child) => {
+            tracing::info!(
+                "shell_open: handed to explorer.exe (pid={}) so it opens unelevated: {target}",
+                child.id()
+            );
+            Ok(())
+        }
+        Err(e) => {
+            tracing::warn!("shell_open: could not launch explorer.exe for {target}: {e}");
+            Err(format!("failed to launch explorer.exe: {e}"))
+        }
+    }
 }
 
 #[cfg(not(target_os = "windows"))]
 pub fn shell_open(target: &str) -> Result<(), String> {
+    tracing::info!("shell_open: {target}");
     open::that(target).map_err(|e| format!("failed to open target: {e}"))
 }
 
@@ -41,6 +53,7 @@ pub fn shell_open(target: &str) -> Result<(), String> {
 /// before the string ever reaches the shell.
 pub fn open_external_url(url: &str) -> Result<(), String> {
     if !is_http_url(url) {
+        tracing::warn!("open_external_url: refusing non-http(s) target: {url}");
         return Err(format!("refusing to open non-http(s) URL: {url}"));
     }
     shell_open(url)

--- a/src-tauri/src/utils/shell_open.rs
+++ b/src-tauri/src/utils/shell_open.rs
@@ -1,0 +1,78 @@
+//! Opening external URLs / folders without handing them our admin token.
+//!
+//! MapleLink self-elevates at startup (needed for auto-paste and LR DLL
+//! injection), so every process it spawns inherits the elevated token. A browser
+//! launched that way writes its profile as Administrator, which leaves
+//! admin-owned files in the user's real profile — the browser then fails to read
+//! them back when it next runs normally, and presents as a wiped profile.
+//!
+//! Handing the target to `explorer.exe` instead lets the already-running,
+//! non-elevated shell open it as the desktop user, so the browser stays
+//! unelevated.
+
+/// Open `target` via the desktop shell so it does NOT inherit our elevated token.
+///
+/// `target` is passed to the shell verbatim, so callers must only pass trusted
+/// values (our own paths) — anything user- or server-supplied must go through
+/// [`open_external_url`], which enforces an http(s) scheme.
+///
+/// Note: `explorer.exe` returns immediately and its exit code does not reflect
+/// whether the target opened, so only a spawn failure can be reported.
+#[cfg(target_os = "windows")]
+pub fn shell_open(target: &str) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    std::process::Command::new("explorer.exe")
+        .arg(target)
+        .creation_flags(0x0800_0000) // CREATE_NO_WINDOW
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("failed to launch explorer.exe: {e}"))
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn shell_open(target: &str) -> Result<(), String> {
+    open::that(target).map_err(|e| format!("failed to open target: {e}"))
+}
+
+/// Open an external web link, rejecting anything that isn't http(s).
+///
+/// The shell would happily launch a local executable or a `file:` path, and some
+/// callers forward URLs parsed out of server responses, so the scheme is checked
+/// before the string ever reaches the shell.
+pub fn open_external_url(url: &str) -> Result<(), String> {
+    if !is_http_url(url) {
+        return Err(format!("refusing to open non-http(s) URL: {url}"));
+    }
+    shell_open(url)
+}
+
+/// Whether `url` is an `http://` or `https://` URL.
+fn is_http_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.starts_with("http://") || lower.starts_with("https://")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_http_url;
+
+    #[test]
+    fn accepts_http_and_https_any_case() {
+        assert!(is_http_url("http://example.com"));
+        assert!(is_http_url("https://example.com/a?b=c"));
+        assert!(is_http_url("HTTPS://EXAMPLE.COM"));
+    }
+
+    #[test]
+    fn rejects_everything_else() {
+        // A local executable is the case that matters: the shell would run it.
+        assert!(!is_http_url(r"C:\Windows\System32\calc.exe"));
+        assert!(!is_http_url("file:///C:/Windows/System32/calc.exe"));
+        assert!(!is_http_url("javascript:alert(1)"));
+        assert!(!is_http_url("\\\\evil-share\\payload.exe"));
+        assert!(!is_http_url(""));
+        // Scheme must be at the start, not merely present.
+        assert!(!is_http_url(" https://example.com"));
+        assert!(!is_http_url("nothttps://example.com"));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -366,9 +366,7 @@ export function App() {
               </button>
               <button
                 onClick={() => {
-                  import("@tauri-apps/plugin-shell").then(({ open }) =>
-                    open("https://maplestory.beanfun.com/download"),
-                  );
+                  commands.openExternal("https://maplestory.beanfun.com/download").catch(() => {});
                   setPatcherInfo(null);
                 }}
                 className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"

--- a/src/features/launcher/AccountContextMenu.tsx
+++ b/src/features/launcher/AccountContextMenu.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "../../lib/i18n";
-import { open } from "@tauri-apps/plugin-shell";
 import { commands } from "../../lib/tauri";
 import { useRefreshAccounts } from "../../lib/hooks/use-accounts";
 import { useQueryClient } from "@tanstack/react-query";
@@ -428,7 +427,7 @@ export function AccountContextMenu({ position, account, onClose }: AccountContex
   }
 
   function handleWebsite() {
-    open("https://maplestory.beanfun.com/");
+    commands.openExternal("https://maplestory.beanfun.com/").catch(() => {});
     onClose();
   }
 

--- a/src/features/login/VerifyForm.tsx
+++ b/src/features/login/VerifyForm.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "../../lib/i18n";
 import { commands } from "../../lib/tauri";
 import { useAuthStore } from "../../lib/stores/auth-store";
 import { useLogin } from "../../lib/hooks/use-auth";
-import { open } from "@tauri-apps/plugin-shell";
 import type { AdvanceCheckState } from "../../lib/types";
 
 interface VerifyFormProps {
@@ -207,7 +206,7 @@ export function VerifyForm({
           {t("login.verify.web_required")}
         </p>
         <button
-          onClick={() => open(webVerifyUrl)}
+          onClick={() => commands.openExternal(webVerifyUrl).catch(() => {})}
           className="w-full rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-5 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-white uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95"
         >
           {t("login.verify.open_browser")}

--- a/src/features/shared/AnnouncementModal.tsx
+++ b/src/features/shared/AnnouncementModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "../../lib/i18n";
+import { commands } from "../../lib/tauri";
 import {
   ANNOUNCEMENT_BEANFUN_URL,
   ANNOUNCEMENT_FORCED_SECONDS,
@@ -7,7 +8,7 @@ import {
 } from "../../lib/announcement";
 
 function openExternal(url: string) {
-  import("@tauri-apps/plugin-shell").then(({ open }) => open(url));
+  commands.openExternal(url).catch(() => {});
 }
 
 /** One project row: coloured dot + bold name (+ optional tag), description below. */

--- a/src/features/toolbox/AboutTab.tsx
+++ b/src/features/toolbox/AboutTab.tsx
@@ -59,7 +59,7 @@ export function AboutTab() {
   }
 
   function openExternal(url: string) {
-    import("@tauri-apps/plugin-shell").then(({ open }) => open(url));
+    commands.openExternal(url).catch(() => {});
   }
 
   return (

--- a/src/features/toolbox/GameDownloadModal.tsx
+++ b/src/features/toolbox/GameDownloadModal.tsx
@@ -6,7 +6,7 @@ import type { GameDownloadDto } from "../../lib/types";
 import { Modal } from "../../components/Modal";
 
 function openExternal(url: string) {
-  import("@tauri-apps/plugin-shell").then(({ open }) => open(url));
+  commands.openExternal(url).catch(() => {});
 }
 
 function DownloadRow({ item }: { item: GameDownloadDto }) {

--- a/src/features/toolbox/WebLaunchTab.tsx
+++ b/src/features/toolbox/WebLaunchTab.tsx
@@ -91,7 +91,7 @@ function TestRow({
 const GAMANIA_DOWNLOAD_URL = "https://tw.beanfun.com/ggm/index.aspx";
 
 function openExternal(url: string) {
-  import("@tauri-apps/plugin-shell").then(({ open }) => open(url));
+  commands.openExternal(url).catch(() => {});
 }
 
 /** A labelled on/off switch row for a web-launch behaviour preference. */

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -131,6 +131,14 @@ export const commands = {
   webLaunchTestGamania: () => invoke<WebLaunchTestCode>("web_launch_test_gamania"),
   toggleDebugWindow: (enable: boolean) => invoke("toggle_debug_window", { enable }),
   openLogFolder: () => invoke("open_log_folder"),
+  /**
+   * Open an external http(s) link in the user's browser.
+   *
+   * Always use this instead of `@tauri-apps/plugin-shell`'s `open()`: MapleLink
+   * runs elevated, so a browser it spawns directly inherits the admin token and
+   * corrupts the user's real browser profile.
+   */
+  openExternal: (url: string) => invoke("open_external", { url }),
   getRecentLogs: () => invoke<string>("get_recent_logs"),
   openWebPopup: (url: string, title: string) => invoke("open_web_popup", { url, title }),
   getWebToken: (sessionId: string) => invoke<string>("get_web_token", { sessionId }),


### PR DESCRIPTION
## Problem

MapleLink self-elevates at startup (needed for auto-paste and LR DLL injection), so every process it spawns inherits the admin token. Opening a link through `plugin-shell` therefore launched the user's browser **as Administrator**, which leaves admin-owned files behind in the browser's own profile. The browser then can't read them back when it next runs normally, and presents as a wiped profile with every account signed out.

Reported in #38 (Chrome accounts signed out and removed after clicking the help doc link). The reporter's account matches this chain exactly, including being signed out at the moment the browser first opened from MapleLink.

Every external link was affected — About, game download, web-launch, the announcement modal, the account context menu, and the advance-check verify link — plus the log folder.

## Fix

Route external links through `explorer.exe`: the already-running, unelevated shell opens them as the desktop user. Elevation itself is unchanged, so auto-paste and the LR game launch still work.

`open_external` rejects anything that isn't `http(s)` — the shell would happily launch a local executable, and `VerifyForm` forwards a URL parsed out of a server response.

`src/` no longer uses `plugin-shell`'s `open()` anywhere.

## Verification

Confirmed on a VM with UAC enabled (`EnableLUA = 1`), cold-starting the browser:

| process | elevated |
|---|---|
| `explorer` | not elevated |
| `MapleLink` | **ELEVATED** |
| root `msedge` (spawned by clicking a link) | **not elevated** |

The root browser process's parent was a since-exited `explorer.exe` — the transient handoff process. Before the fix, a browser launched from the elevated MapleLink would inherit `ELEVATED`.

Note this is **not reproducible on a machine with UAC disabled** — there every process is already admin, so there is no unelevated shell to hand off to and no ACL mismatch to cause the corruption in the first place.

## Notes

- `explorer.exe` returns immediately and its exit code doesn't reflect whether the target opened, so only a spawn failure is reported.
- Added logging of the elevation state and every `shell_open` handoff, so this class of issue is diagnosable from the log alone.

Checks: `cargo fmt` / `clippy -D warnings` / `cargo test --lib` (93 passed, incl. 4 new URL-validation tests) / `tsc -b` / `eslint` / `prettier --check` all pass.