### PR TITLE
chore(deps): bump serde_with to 3.21.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3468,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3488,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
## What

Bump `serde_with` 3.20.0 → 3.21.0. Lockfile only, scoped to `serde_with` + `serde_with_macros` (8-line diff, version + checksum each).

## Why

Closes the one open Dependabot alert ([serde_with #13](https://github.com/lshw54/maplelink/security/dependabot), moderate). The `KeyValueMap` serializer preallocates from `len - 1` before checking the element has a first key field, so an empty inner sequence or map entry panics and aborts the process.

**Reviewer note — this is housekeeping, not an exploitable hole being closed:**

- We don't depend on `serde_with` directly; it arrives via `tauri-utils`.
- `serde_with`, `serde_as` and `KeyValueMap` appear nowhere in `src-tauri/src/` or `Cargo.toml`.
- Triggering it requires serializing attacker-controlled data *through `KeyValueMap`* — we have no such code path.
- The advisory scopes the impact to a local attacker causing DoS. No data exposure, no code execution.

Worth applying to clear the alert, but not urgent.

## Reviewer note — why the lockfile was hand-edited

A plain `cargo update -p serde_with` (even with `--precise`) re-unifies the whole tree as a side effect. `iana-time-zone` allows the range `windows-core >=0.56, <=0.62`, and `0.56.0` is already in the tree (required by `trash` → `windows 0.56.0`), so cargo collapses iana's `windows-core 0.62.2` down to `0.56.0` — a 6-minor downgrade of a transitive dep, unrelated to this advisory.

To keep the PR doing exactly one thing, the two `serde_with` entries were edited by hand and the result verified with `cargo build --locked`, which cargo accepts as-is (checksums valid, dependency graph self-consistent). `iana-time-zone` still resolves to `windows-core 0.62.2`; all three `windows-core` versions in the tree are untouched.

No `Cargo.toml` change and no Tauri bump: `tauri-utils 2.9.1` requires `serde_with ^3`, which 3.21.0 satisfies.

## How to test

No behaviour change. The lock diff is the whole review surface: only the `serde_with` / `serde_with_macros` version + checksum lines move. Verified with `cargo build --locked` / `cargo clippy --all-targets --locked -- -D warnings` / `cargo test --lib --locked` (96 pass).

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes — unaffected, no frontend change
- [x] Tested locally with `cargo tauri dev` — **not done**; verified with `cargo build --locked` (compiles clean against 3.21.0) and `cargo test --lib --locked` (96 pass).
- [x] No breaking changes to existing features — transitive, semver-compatible, unused by our code, and no other dependency moves.