### PR TITLE
fix(classic): also log the session into the regular account list

### DIFF
--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -396,6 +396,15 @@ export function MainPage() {
               </div>
             )}
 
+            {/* +86 accounts can't play classic — only relevant to the HK id-pass
+                path (a GamaPass session is TW). */}
+            {showClassic && session?.region === "HK" && (
+              <p className="flex max-w-[220px] items-start gap-1.5 text-center text-[10px] leading-snug text-text-faint">
+                <span className="shrink-0">ℹ️</span>
+                <span>{t("login.classic_no_cn")}</span>
+              </p>
+            )}
+
             {/* Circular PLAY button */}
             <button
               onClick={handlePlayClick}

--- a/src/features/login/LoginPage.tsx
+++ b/src/features/login/LoginPage.tsx
@@ -50,19 +50,11 @@ export function LoginPage() {
   // Listen for GamePass login completion event from backend
   useEffect(() => {
     const unlistenComplete = listen<SessionDto>("gamepass-login-complete", async (event) => {
-      // Classic (懷舊服) via GamePass reuses this flow but ends in the portal, not
-      // the game grid — same as the HK classic path.
-      if (useUiStore.getState().classicMode) {
-        useUiStore.setState({
-          addingSession: false,
-          loginView: "normal",
-          classicStatus: "launching",
-        });
-        commands.openClassicLogin(event.payload.sessionId).catch(() => {
-          useUiStore.setState({ classicStatus: "failed" });
-        });
-        return;
-      }
+      // Classic (懷舊服) via GamePass shares the same beanfun account as the
+      // regular server, so it's set up exactly like a regular GamePass login — the
+      // session joins the account list with the same polling / keep-alive — and
+      // THEN we also fire the classic portal launch below.
+      const classic = useUiStore.getState().classicMode;
       useAuthStore.getState().addSession(event.payload, undefined, "gamepass");
       try {
         const accounts = await commands.getGameAccounts(event.payload.sessionId);
@@ -73,6 +65,12 @@ export function LoginPage() {
       await queryClient.invalidateQueries({ queryKey: ["gameAccounts"] });
       useUiStore.setState({ addingSession: false, loginView: "normal" });
       setPage("main");
+      if (classic) {
+        useUiStore.setState({ classicStatus: "launching" });
+        commands.openClassicLogin(event.payload.sessionId).catch(() => {
+          useUiStore.setState({ classicStatus: "failed" });
+        });
+      }
     });
 
     const unlistenError = listen<string>("gamepass-login-error", (event) => {

--- a/src/features/login/NormalLoginForm.tsx
+++ b/src/features/login/NormalLoginForm.tsx
@@ -304,6 +304,12 @@ export function NormalLoginForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex w-full flex-col">
+      {classicMode && (
+        <p className="mb-3 flex items-start gap-1.5 text-[11px] leading-snug text-text-dim">
+          <span className="shrink-0">ℹ️</span>
+          <span>{t("login.classic_no_cn")}</span>
+        </p>
+      )}
       {classicMode &&
         (classicCheck && !(classicCheck.ngmRegistered && classicCheck.ngmExeExists) ? (
           // NGM missing — prominent warning with a direct download.
@@ -712,6 +718,10 @@ export function NormalLoginForm({
               {classicCheck?.webview2Version ?? t("login.check_unknown")}
             </span>
           </div>
+          <p className="flex items-start gap-1.5 pt-0.5 text-[11px] leading-snug text-text-dim">
+            <span className="shrink-0">ℹ️</span>
+            <span>{t("login.classic_no_cn")}</span>
+          </p>
           {!classicCheck?.ngmRegistered && (
             <div className="mt-1 flex flex-col gap-2 rounded-md bg-[rgba(234,179,8,0.08)] px-2.5 py-2">
               <p className="text-[11px] leading-relaxed text-yellow-500">

--- a/src/lib/hooks/use-auth.ts
+++ b/src/lib/hooks/use-auth.ts
@@ -144,23 +144,13 @@ export function useLogin() {
       }
     },
     onSuccess: async (session: SessionDto) => {
-      // Classic (懷舊服): the experience lives in the portal webview. Open it
-      // and stop — the backend session already holds the cookies it needs, so we
-      // don't add it to the game-account grid store or navigate to main.
-      if (useUiStore.getState().classicMode) {
-        useUiStore.setState({ addingSession: false, classicStatus: "launching" });
-        commands.openClassicLogin(session.sessionId).catch(() => {
-          useUiStore.setState({ classicStatus: "failed" });
-        });
-        // If a regular session already exists (this classic launch was started
-        // from the account tab's "+"), return to the account list rather than
-        // stranding the user on the login page — the app-level overlay shows the
-        // classic progress over the main page.
-        if (useAuthStore.getState().isAuthenticated) {
-          useUiStore.getState().setPage("main");
-        }
-        return;
-      }
+      // Classic (懷舊服) and the regular server share the same beanfun account and
+      // are interconnected, so a classic login is set up EXACTLY like a regular one
+      // — the session joins the account list and gets the same polling / keep-alive
+      // — and THEN we also fire the classic portal launch below. This lets the user
+      // play either server from a single login.
+      const classic = useUiStore.getState().classicMode;
+
       useAuthStore.getState().addSession(session);
       let accountCount = -1;
       try {
@@ -192,6 +182,18 @@ export function useLogin() {
       // Clear addingSession flag, reset login view, and navigate to main
       useUiStore.setState({ addingSession: false, loginView: "normal" });
       useUiStore.getState().setPage("main");
+
+      // Classic: now that the regular session + account list are in place, launch
+      // the classic portal on this same session. The app-level overlay shows its
+      // progress over the account list. Skip the regular auto-launch below — the
+      // classic launch is this login's launch.
+      if (classic) {
+        useUiStore.setState({ classicStatus: "launching" });
+        commands.openClassicLogin(session.sessionId).catch(() => {
+          useUiStore.setState({ classicStatus: "failed" });
+        });
+        return;
+      }
 
       // Auto-launch game if enabled
       const cfg = useConfigStore.getState().config;

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -20,6 +20,7 @@
   "login.mode_tw": "Taiwan",
   "login.mode_classic": "Classic",
   "login.classic_hint": "Sign in with a Hong Kong beanfun account; MapleStory Classic launches automatically.",
+  "login.classic_no_cn": "Classic supports Hong Kong (HK) beanfun accounts only — not +86 (mainland China) accounts.",
   "login.classic_check": "Re-check",
   "login.classic_checking": "Checking Classic environment…",
   "login.classic_ready": "Classic environment ready",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -20,6 +20,7 @@
   "login.mode_tw": "台湾",
   "login.mode_classic": "怀旧服",
   "login.classic_hint": "以香港 beanfun 账号登录，登录后自动启动《经典版》。",
+  "login.classic_no_cn": "经典版仅支持香港（HK）beanfun 账号，不支持 +86（中国大陆）账号。",
   "login.classic_check": "重新检测",
   "login.classic_checking": "正在检测经典版环境…",
   "login.classic_ready": "经典版环境已就绪",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -20,6 +20,7 @@
   "login.mode_tw": "台灣",
   "login.mode_classic": "懷舊服",
   "login.classic_hint": "以香港 beanfun 帳號登入，登入後自動啟動《經典版》。",
+  "login.classic_no_cn": "經典版僅支援香港（HK）beanfun 帳號，不支援 +86（中國大陸）帳號。",
   "login.classic_check": "重新檢測",
   "login.classic_checking": "正在檢測經典版環境…",
   "login.classic_ready": "經典版環境已就緒",


### PR DESCRIPTION
## Problem

Logging into MapleStory Classic (懷舊服) opened the portal and returned early. The session never joined the regular account list, got no session tab, and skipped the frontend polling / keep-alive that a regular login sets up — even though Classic and the regular server share the same beanfun account and are interconnected.

## Fix

Classic login now runs the **full regular setup** first (`addSession` → fetch game accounts → navigate to the account list), then fires the classic portal launch. Applied to both classic entry points:

- **HK id-pass** — `useLogin` `onSuccess`
- **TW GamaPass** — `gamepass-login-complete` listener

The regular auto-launch is skipped in classic mode (the classic portal launch is that login's launch). The backend ping loop already iterated every session in the Rust session store, so it always covered classic sessions; now the frontend account list + keep-alive match a regular login exactly, so the user can play either server from a single login.

The already-logged-in reuse path in `NormalLoginForm.handleSubmit` is unchanged — it still avoids a second login (which would kick the existing session) and just launches classic on the session already in the list.

## Note

This is the fix behind withdrawing the v0.4.4 release; re-release once merged.