### PR TITLE
feat(login): enlarge default QR code size for easier scanning

### DIFF
--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -145,7 +145,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
 
       <div className="flex w-full flex-col items-center gap-3 rounded-[14px] border border-border bg-[var(--surface)] p-5">
         <div
-          className={`flex items-center justify-center rounded-xl bg-white shadow-[0_2px_12px_rgba(0,0,0,0.08)] ${enlarged ? "p-5" : "h-[180px] w-[180px] p-4"}`}
+          className={`flex items-center justify-center rounded-xl bg-white shadow-[0_2px_12px_rgba(0,0,0,0.08)] ${enlarged ? "p-5" : "h-[228px] w-[228px] p-4"}`}
         >
           {status === "loading" ? (
             <div className="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
@@ -155,8 +155,8 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
               alt="QR Code"
               className="block rounded"
               style={{
-                width: enlarged ? 380 : 150,
-                height: enlarged ? 380 : 150,
+                width: enlarged ? 380 : 196,
+                height: enlarged ? 380 : 196,
                 imageRendering: "pixelated",
               }}
             />


### PR DESCRIPTION
## What

Increase the default QR code shown on the QR login view from 150px (180px frame) to 196px (228px frame). It still fits within the existing 350x620 login window, so no window resize is triggered. The "enlarge" button is unchanged and can still grow it further to 380px.

## Why

The default QR was small enough that scanning it often required tapping the "enlarge" button first. Bumping the default size means the extra tap usually isn't needed anymore.

## How to test

1. Run `cargo tauri dev`, switch to the TW region.
2. Go to the login page and click "QR Code Login".
3. Confirm the QR code is noticeably larger and the card/window layout doesn't overflow or break.
4. Confirm the "enlarge"/"shrink" button still works correctly (toggles to the 380px large view and back to the new default size).
5. Confirm "Copy QR" and "Copy Link" buttons still work as before.

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes
- [x] Tested locally with `cargo tauri dev`
- [x] No breaking changes to existing features