### PR TITLE
fix(login): auto-launch game after QR and TOTP login, not just password login

### DIFF
--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "../../lib/i18n";
 import { commands } from "../../lib/tauri";
 import { useAuthStore } from "../../lib/stores/auth-store";
 import { useUiStore } from "../../lib/stores/ui-store";
+import { autoLaunchGameIfEnabled } from "../../lib/hooks/use-auth";
 import type { QrCodeData, QrPollResult } from "../../lib/types";
 
 interface QrLoginFormProps {
@@ -60,6 +61,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
             // Reset window size if enlarged
             commands.resizeWindow("login").catch(() => {});
             useUiStore.getState().setPage("main");
+            autoLaunchGameIfEnabled(sessionId);
           }
         } else if (result.status === "expired") {
           stopPolling();

--- a/src/lib/hooks/use-auth.ts
+++ b/src/lib/hooks/use-auth.ts
@@ -5,10 +5,36 @@ import { useAuthStore } from "../stores/auth-store";
 import { useConfigStore } from "../stores/config-store";
 import { useUiStore } from "../stores/ui-store";
 import { useErrorToastStore } from "../stores/error-toast-store";
-import type { SessionDto, QrPollResult } from "../types";
+import type { SessionDto } from "../types";
 
 /** Translate outside React render (mutation callbacks) using the current language. */
 const tr = (key: string) => getTranslation(useUiStore.getState().language, key);
+
+/** Launch the game after login if the user enabled autoLaunchGame. Shared by every login path (password, QR, TOTP). */
+export function autoLaunchGameIfEnabled(sessionId: string) {
+  const cfg = useConfigStore.getState().config;
+  if (!cfg?.autoLaunchGame) return;
+  setTimeout(async () => {
+    try {
+      let pid = 0;
+      if (cfg.traditionalLogin) {
+        pid = await commands.launchGameDirect();
+      } else {
+        const entry = useAuthStore.getState().sessions.get(sessionId);
+        const first = entry?.gameAccounts?.[0];
+        if (first) {
+          pid = await commands.launchGame(sessionId, first.id);
+        }
+      }
+      if (pid > 0) {
+        useUiStore.getState().setGamePid(pid);
+        useUiStore.getState().setGameRunning(true);
+      }
+    } catch {
+      /* auto-launch failure is non-critical */
+    }
+  }, 500);
+}
 
 /** Login with account + password. Creates a new session, then authenticates. */
 export function useLogin() {
@@ -195,52 +221,7 @@ export function useLogin() {
         return;
       }
 
-      // Auto-launch game if enabled
-      const cfg = useConfigStore.getState().config;
-      if (cfg?.autoLaunchGame) {
-        setTimeout(async () => {
-          try {
-            let pid = 0;
-            if (cfg.traditionalLogin) {
-              pid = await commands.launchGameDirect();
-            } else {
-              const entry = useAuthStore.getState().sessions.get(session.sessionId);
-              const first = entry?.gameAccounts?.[0];
-              if (first) {
-                pid = await commands.launchGame(session.sessionId, first.id);
-              }
-            }
-            if (pid > 0) {
-              useUiStore.getState().setGamePid(pid);
-              useUiStore.getState().setGameRunning(true);
-            }
-          } catch {
-            /* auto-launch failure is non-critical */
-          }
-        }, 500);
-      }
-    },
-  });
-}
-
-/** Poll QR login status. Updates auth store when confirmed. */
-export function useQrLoginPoll() {
-  const queryClient = useQueryClient();
-
-  return useMutation<
-    QrPollResult,
-    Error,
-    { sessionId: string; sessionKey: string; verificationToken: string }
-  >({
-    mutationFn: ({ sessionId, sessionKey, verificationToken }) =>
-      commands.qrLoginPoll(sessionId, sessionKey, verificationToken),
-    onSuccess: async (result: QrPollResult) => {
-      if (result.status === "confirmed" && result.session) {
-        useAuthStore.getState().addSession(result.session, undefined, "qr");
-        const accounts = await commands.getGameAccounts(result.session.sessionId);
-        useAuthStore.getState().updateGameAccounts(result.session.sessionId, accounts);
-        await queryClient.invalidateQueries({ queryKey: ["gameAccounts"] });
-      }
+      autoLaunchGameIfEnabled(session.sessionId);
     },
   });
 }
@@ -275,6 +256,8 @@ export function useTotpVerify() {
       // Reset login view, clear addingSession, navigate to main
       useUiStore.setState({ addingSession: false, loginView: "normal" });
       useUiStore.getState().setPage("main");
+
+      autoLaunchGameIfEnabled(session.sessionId);
     },
   });
 }


### PR DESCRIPTION
## What

Fix auto-launch-game-after-login not firing for QR code login or TOTP (HK 2FA) login — it only ever ran on the password login path.

- Extracted the auto-launch logic (previously inlined in `useLogin`'s `onSuccess`) into a shared `autoLaunchGameIfEnabled(sessionId)` helper in `use-auth.ts`.
- Wired it into `QrLoginForm.tsx`'s actual QR-confirm success handler, and into `useTotpVerify`'s `onSuccess`.
- Removed `useQrLoginPoll` — it was dead code never imported anywhere; `QrLoginForm` has always run its own `setInterval` polling loop directly against `commands.qrLoginPoll`, so patching that hook alone was not effective.

## Why

QR login is the default login view for TW users (`defaultLoginView: "qr"`), so most users hitting "auto-launch game after login" never saw it work. Confirmed via `maplelink.log`: QR login succeeded but no `launch_game` / `launch_game_direct` command was ever invoked afterward.

## How to test

1. Enable "Auto-launch game after login" in Advanced settings.
2. Log in via QR code — game should launch automatically ~500ms after reaching the account list.
3. Log in via TOTP (HK region) — same expected behavior.
4. Log in via account/password (TW or HK) — unaffected, still works as before.

## Checklist

- [x] `npm run lint` passes
- [x] `tsc --noEmit` passes
- [x] Tested locally with a release build (QR login confirmed working)
- [x] No breaking changes to existing features
