### PR TITLE
fix(window): remove duplicate drag trigger causing post-drag input freeze

### DIFF
--- a/src/features/shared/Titlebar.tsx
+++ b/src/features/shared/Titlebar.tsx
@@ -48,7 +48,6 @@ export function Titlebar() {
 
   return (
     <div
-      data-tauri-drag-region
       onMouseDown={handleDragStart}
       className="flex h-[34px] shrink-0 items-center"
       style={{ zIndex: 10, position: "relative" }}


### PR DESCRIPTION
## What

Titlebar had both Tauri's native `data-tauri-drag-region` attribute and a
manual `onMouseDown -> startDragging()` handler on the same element, so a
single mousedown fired two native drag-move loops back to back.

- Removed `data-tauri-drag-region` from `Titlebar.tsx`, keeping only the
  manual handler — the same pattern already used by `SessionTabs.tsx` and
  `DebugConsole.tsx`, neither of which ever had the attribute.

## Why

On Windows, starting a native drag-move (`WM_NCLBUTTONDOWN` + `HTCAPTION`)
enters a blocking modal loop until the mouse button is released. With both
triggers wired up, dragging the titlebar started two of these loops per
mousedown:

1. The native `data-tauri-drag-region` handler fires first and blocks until
   mouseup.
2. Once that returns, React's queued `onMouseDown` handler fires and calls
   `startDragging()` again — but the mouse is already up, so this second
   loop is left waiting for an input that already happened.

That stuck second loop is what made the window unresponsive to further
dragging/clicking for a few seconds after every drag-release, including the
very first drag right after launch.

## How to test

1. Launch the app, drag the titlebar to move the window, release.
2. Immediately try to drag again — should respond instantly, no delay.
3. Repeat as the very first action right after launching the app.
4. Confirm buttons in the titlebar (classic/region toggle, toolbox,
   minimize, close) are still unaffected by dragging and remain clickable.

Manually verified locally — the freeze no longer reproduces.

## Checklist

- [x] `npm run lint` passes
- [x] `tsc --noEmit` passes
- [x] Tested locally with a release build (drag freeze confirmed gone)
- [x] No breaking changes to existing features