### PR TITLE
fix(login): follow-ups to the shared auto-launch path

### DIFF
--- a/src/features/launcher/SessionTabs.tsx
+++ b/src/features/launcher/SessionTabs.tsx
@@ -47,7 +47,7 @@ export function SessionTabs() {
   }
 
   function handleAdd() {
-    useUiStore.getState().addingSession = true;
+    useUiStore.setState({ addingSession: true });
     setPage("login");
   }
 

--- a/src/features/login/LoginPage.tsx
+++ b/src/features/login/LoginPage.tsx
@@ -25,6 +25,7 @@ export function LoginPage() {
   const queryClient = useQueryClient();
   const persistedView = useUiStore((s) => s.loginView);
   const classicMode = useUiStore((s) => s.classicMode);
+  const addingSession = useUiStore((s) => s.addingSession);
   const [view, setViewLocal] = useState<LoginView>(() => {
     if (persistedView) return persistedView as LoginView;
     // First mount this session — fall back to the user's configured default.
@@ -153,11 +154,11 @@ export function LoginPage() {
               onWebLaunch={() => setPage("web_launch")}
             />
 
-            {useUiStore.getState().addingSession && (
+            {addingSession && (
               <button
                 type="button"
                 onClick={() => {
-                  useUiStore.getState().addingSession = false;
+                  useUiStore.setState({ addingSession: false });
                   setPage("main");
                 }}
                 className="mt-3 w-full rounded-lg border border-border bg-transparent px-3.5 py-2 text-[12px] font-semibold text-text-dim transition-colors hover:border-accent hover:text-accent"

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -56,8 +56,12 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
             const accounts = await commands.getGameAccounts(sessionId);
             useAuthStore.getState().updateGameAccounts(sessionId, accounts);
             // Clear persisted QR state
-            useUiStore.setState({ qrSessionId: null, qrData: null, loginView: "normal" });
-            useUiStore.getState().addingSession = false;
+            useUiStore.setState({
+              qrSessionId: null,
+              qrData: null,
+              loginView: "normal",
+              addingSession: false,
+            });
             // Reset window size if enlarged
             commands.resizeWindow("login").catch(() => {});
             useUiStore.getState().setPage("main");

--- a/src/lib/hooks/use-auth.ts
+++ b/src/lib/hooks/use-auth.ts
@@ -14,17 +14,20 @@ const tr = (key: string) => getTranslation(useUiStore.getState().language, key);
 export function autoLaunchGameIfEnabled(sessionId: string) {
   const cfg = useConfigStore.getState().config;
   if (!cfg?.autoLaunchGame) return;
-  setTimeout(async () => {
+  void (async () => {
     try {
       let pid = 0;
       if (cfg.traditionalLogin) {
+        // Direct launch passes no account or OTP, so the account list is irrelevant.
         pid = await commands.launchGameDirect();
       } else {
-        const entry = useAuthStore.getState().sessions.get(sessionId);
-        const first = entry?.gameAccounts?.[0];
-        if (first) {
-          pid = await commands.launchGame(sessionId, first.id);
-        }
+        // Every login path awaits the account fetch and lands on the account list
+        // before asking for a launch, so the store already holds the final list —
+        // there is nothing to wait out. An empty list is a legitimate result (a
+        // beanfun account with no game account yet); there is just nothing to launch.
+        const first = useAuthStore.getState().sessions.get(sessionId)?.gameAccounts?.[0];
+        if (!first) return;
+        pid = await commands.launchGame(sessionId, first.id);
       }
       if (pid > 0) {
         useUiStore.getState().setGamePid(pid);
@@ -33,7 +36,7 @@ export function autoLaunchGameIfEnabled(sessionId: string) {
     } catch {
       /* auto-launch failure is non-critical */
     }
-  }, 500);
+  })();
 }
 
 /** Login with account + password. Creates a new session, then authenticates. */

--- a/src/lib/hooks/use-auth.ts
+++ b/src/lib/hooks/use-auth.ts
@@ -233,6 +233,12 @@ export function useTotpVerify() {
   return useMutation<SessionDto, Error, { sessionId: string; code: string }>({
     mutationFn: ({ sessionId, code }) => commands.totpVerify(sessionId, code),
     onSuccess: async (session: SessionDto) => {
+      // Classic (懷舊服) is reached through the HK id-pass login, which is also
+      // the path that can demand 2FA — so a classic login can finish here rather
+      // than in useLogin's onSuccess. Set the session up as a regular one and
+      // launch classic below, exactly as that path does.
+      const classic = useUiStore.getState().classicMode;
+
       useAuthStore.getState().addSession(session);
 
       // Save pending credentials from the login attempt
@@ -256,6 +262,16 @@ export function useTotpVerify() {
       // Reset login view, clear addingSession, navigate to main
       useUiStore.setState({ addingSession: false, loginView: "normal" });
       useUiStore.getState().setPage("main");
+
+      // Classic launch replaces the regular auto-launch — otherwise a 2FA
+      // classic login would start the regular game instead.
+      if (classic) {
+        useUiStore.setState({ classicStatus: "launching" });
+        commands.openClassicLogin(session.sessionId).catch(() => {
+          useUiStore.setState({ classicStatus: "failed" });
+        });
+        return;
+      }
 
       autoLaunchGameIfEnabled(session.sessionId);
     },


### PR DESCRIPTION
Follow-ups to #51, which moved the post-login auto-launch into a helper shared by every login path.

## Classic launched the regular game after 2FA

The HK id-pass login is the entry point for MapleStory Classic, and it is also the path that can demand 2FA. With 2FA on, the login finishes in `useTotpVerify` instead of `useLogin` — and only the latter had the classic branch, so choosing Classic started the **regular** game.

`useTotpVerify` now checks `classicMode` the same way and runs the classic launch in place of the regular auto-launch.

## `addingSession` was mutated instead of set

`useUiStore.getState().addingSession = true` writes straight through the state object, bypassing Zustand, so nothing re-renders. The "← back to accounts" button on the login page did not appear or disappear when adding a session from the account tab's "+" until some other render happened to run.

All three sites now go through `setState`, and `LoginPage` subscribes to the flag rather than reading it during render. The QR path folds its flag clear into the `setState` it already makes.

## Auto-launch slept 500ms first

The auto-launch waited a fixed 500ms and only then read the session's first game account. Every login path already awaits the account fetch and lands on the account list before asking for a launch, so the store is final by then — the delay guarded nothing and only held the launch back.

It reads the list directly now. An empty list stays a no-op: that means the beanfun account has no game account yet, which is a normal state, not something to wait out or report.

## Checks

`tsc`, `eslint`, `prettier --check` — all green. Frontend-only; no Rust touched.