### PR TITLE
feat(classic): detect where the Classic client is installed

### DIFF
--- a/src-tauri/src/services/classic_service.rs
+++ b/src-tauri/src/services/classic_service.rs
@@ -163,6 +163,72 @@ pub struct ClassicCheck {
     /// Installed WebView2 runtime version (drives whether the launch prompt can
     /// be auto-suppressed), if detectable.
     pub webview2_version: Option<String>,
+    /// The Classic client's executable, wherever it turned out to be installed.
+    pub game_exe: Option<String>,
+}
+
+/// The Classic client's executable, inside whichever folder it was installed to.
+const CLASSIC_EXE: &str = "Maplestory_Classic.exe";
+
+/// Locate the installed Classic client.
+///
+/// Nexon Game Manager records the install folder as `RootPath` under a per-title
+/// subkey of `Nexon` — the subkey name is an encoded id (base64 of something like
+/// `2982_2141_live_837`), so the keys are enumerated and matched on actually
+/// holding the client, rather than assuming an id or an install drive. Falls back
+/// to the usual install folders across the machine's drives, since a user who
+/// moved the game may also have lost the registry entry.
+#[cfg(target_os = "windows")]
+pub fn detect_game_exe() -> Option<String> {
+    use winreg::enums::{HKEY_LOCAL_MACHINE, KEY_READ, KEY_WOW64_32KEY, KEY_WOW64_64KEY};
+    use winreg::RegKey;
+
+    let exe_in = |dir: &str| {
+        let exe = std::path::Path::new(dir).join(CLASSIC_EXE);
+        exe.is_file().then(|| exe.to_string_lossy().to_string())
+    };
+
+    // NGM is 32-bit, so its keys land under WOW6432Node; read the 64-bit view too
+    // in case a future build registers there instead.
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    for flags in [KEY_WOW64_32KEY, KEY_WOW64_64KEY] {
+        let Ok(nexon) = hklm.open_subkey_with_flags(r"SOFTWARE\Nexon", KEY_READ | flags) else {
+            continue;
+        };
+        for title in nexon.enum_keys().flatten() {
+            let root = nexon
+                .open_subkey_with_flags(&title, KEY_READ | flags)
+                .and_then(|k| k.get_value::<String, _>("RootPath"));
+            if let Ok(root) = root {
+                if let Some(exe) = exe_in(&root) {
+                    tracing::info!("classic: client found via Nexon\\{title}: {exe}");
+                    return Some(exe);
+                }
+            }
+        }
+    }
+
+    for drive in ('C'..='Z').map(|d| format!("{d}:")) {
+        for base in [
+            r"\Program Files\Gamania",
+            r"\Program Files (x86)\Gamania",
+            r"\Gamania",
+        ] {
+            let dir = format!("{drive}{base}\\maplestory_classic");
+            if let Some(exe) = exe_in(&dir) {
+                tracing::info!("classic: client found at a well-known path: {exe}");
+                return Some(exe);
+            }
+        }
+    }
+
+    tracing::debug!("classic: no installed client found");
+    None
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn detect_game_exe() -> Option<String> {
+    None
 }
 
 /// Check that the local prerequisites for the classic launch are in place.
@@ -207,6 +273,8 @@ pub fn self_check(manual_path: &str) -> ClassicCheck {
                 .and_then(|k| k.get_value::<String, _>("pv"))
         })
         .ok();
+
+    check.game_exe = detect_game_exe();
 
     check
 }

--- a/src/features/login/NormalLoginForm.tsx
+++ b/src/features/login/NormalLoginForm.tsx
@@ -710,6 +710,23 @@ export function NormalLoginForm({
             </p>
           )}
           <div className="flex items-center gap-2">
+            <span className={classicCheck?.gameExe ? "text-green-500" : "text-red-500"}>
+              {classicCheck?.gameExe ? "✓" : "✗"}
+            </span>
+            <span className="flex-1 text-[var(--text)]">{t("login.check_classic_game")}</span>
+          </div>
+          {classicCheck?.gameExe ? (
+            <p className="pl-6 font-mono text-[10px] break-all text-text-faint">
+              {classicCheck.gameExe}
+            </p>
+          ) : (
+            classicCheck && (
+              <p className="pl-6 text-[11px] leading-snug text-yellow-500">
+                {t("login.check_classic_game_missing")}
+              </p>
+            )
+          )}
+          <div className="flex items-center gap-2">
             <span className={classicCheck?.webview2Version ? "text-green-500" : "text-yellow-500"}>
               {classicCheck?.webview2Version ? "✓" : "?"}
             </span>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface ClassicCheckDto {
   ngmExe: string | null;
   ngmExeExists: boolean;
   webview2Version: string | null;
+  gameExe: string | null;
 }
 
 export interface AppConfigDto {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -31,6 +31,8 @@
   "login.classic_manual_path": "Choose path…",
   "login.classic_check_title": "Classic readiness check",
   "login.check_ngm": "Nexon Game Manager installed",
+  "login.check_classic_game": "Classic client installed",
+  "login.check_classic_game_missing": "Classic client not found. Install it from the official portal; if it's installed on another drive and still isn't found, reinstall it once.",
   "login.check_unknown": "not detected",
   "login.check_ngm_missing": "Nexon Game Manager not found — install the Classic client (which includes NGM) first.",
   "login.classic_launching": "Starting MapleStory Classic…",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -31,6 +31,8 @@
   "login.classic_manual_path": "手动选择路径",
   "login.classic_check_title": "经典版环境检测",
   "login.check_ngm": "Nexon Game Manager 已安装",
+  "login.check_classic_game": "经典版游戏已安装",
+  "login.check_classic_game_missing": "未检测到经典版游戏，请先在官方入口安装；若已安装于其他磁盘仍检测不到，请重新安装一次。",
   "login.check_unknown": "未检测到",
   "login.check_ngm_missing": "未检测到 Nexon Game Manager，请先安装经典版客户端（内含 NGM）。",
   "login.classic_launching": "正在启动经典版…",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -31,6 +31,8 @@
   "login.classic_manual_path": "手動選擇路徑",
   "login.classic_check_title": "經典版環境檢測",
   "login.check_ngm": "Nexon Game Manager 已安裝",
+  "login.check_classic_game": "經典版遊戲已安裝",
+  "login.check_classic_game_missing": "未偵測到經典版遊戲，請先於官方入口安裝；若已安裝於其他磁碟機仍偵測不到，請重新安裝一次。",
   "login.check_unknown": "未偵測到",
   "login.check_ngm_missing": "未偵測到 Nexon Game Manager，請先安裝經典版用戶端（內含 NGM）。",
   "login.classic_launching": "正在啟動經典版…",


### PR DESCRIPTION
## Problem

The Classic readiness check only looked for Nexon Game Manager. Whether the Classic client itself was installed — and where — was never checked, so a missing or relocated client still reported "ready" and only failed at launch time.

The default install is `C:\Program Files\Gamania\maplestory_classic\Maplestory_Classic.exe`, but users do move it to another drive, so that path can't be assumed.

## How it detects

NGM already records the install folder, so we read it from there rather than guessing:

- `HKLM\SOFTWARE\Nexon\<encoded-title-id>` → `RootPath`

The subkey name is an encoded id (base64 of something like `2982_2141_live_837`), so the keys are **enumerated** and matched on actually containing `Maplestory_Classic.exe` — no hardcoded id, no assumed drive. NGM is 32-bit so its keys land under `WOW6432Node`; the 64-bit view is read too in case that changes.

Fallback, for when the registry entry is gone: scan the usual `Gamania\maplestory_classic` folders (`Program Files`, `Program Files (x86)`, drive root) across every drive letter.

Verified on a real install — resolves to the correct exe.

## UI

The self-check gains a "Classic client installed" row showing the resolved path, and an explicit message when nothing is found. New keys added to all three locales.

## Note

`ngm://` still drives the actual launch, so this is detection/diagnostics only — no change to how the game starts.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `tsc`, `eslint`, `prettier --check`, i18n parity — all green.