### PR TITLE
fix(launcher): don't convert beans to game points on TW

### DIFF
--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -462,7 +462,9 @@ export function MainPage() {
                 <span className="font-semibold text-accent">
                   {t("launcher.beans")}: <b>{remainPoint}</b>
                 </span>
-                {remainPoint > 0 && (
+                {/* HK beans buy game points at 2.5 : 1. TW is 1 : 1, so the
+                    second figure would only repeat the first. */}
+                {(session?.region ?? region) === "HK" && remainPoint > 0 && (
                   <>
                     <span className="text-text-faint">·</span>
                     <span className="text-text-dim">


### PR DESCRIPTION
## Problem

Reported by a TW player. The beans balance was always followed by a game-points figure computed at 2.5 : 1 — the Hong Kong rate. On Taiwan beans buy game points one for one, so that second number restated the first at 40% of its value:

> 樂豆: 68 · 遊戲點數: 27

A TW player reading that would think they had less than they do.

## Fix

Show the converted figure for HK only. On TW it would only repeat the beans count, so it's dropped rather than shown as an equal number.

The region comes from the **session** rather than the global toggle, since the balance belongs to the account being viewed — the same reasoning the popup windows already use when picking their host.

## Checks

`tsc`, `eslint`, `prettier --check` — all green. Frontend only.