### PR TITLE
feat(update): race the mirrors on speed before downloading

### DIFF
--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,6 +1,6 @@
 //! Tauri commands for the auto-update system.
 
-use tauri::State;
+use tauri::{Emitter, State};
 
 use crate::core::error::AppError;
 use crate::models::app_state::AppState;
@@ -41,7 +41,14 @@ pub async fn apply_update(
     use_proxy: Option<bool>,
     state: State<'_, AppState>,
 ) -> Result<String, ErrorDto> {
-    let url = update_service::get_download_url(&download_url, use_proxy.unwrap_or(false));
+    // Which route is quickest changes through the day, so measure now rather
+    // than trusting the mirror that happened to answer a probe at startup.
+    // Ticking the proxy box keeps GitHub itself out of the race.
+    let forced_proxy = use_proxy.unwrap_or(false);
+    let _ = app.emit("update-probing-mirrors", ());
+    let url =
+        update_service::fastest_download_url(&state.http_client, &download_url, !forced_proxy)
+            .await;
 
     let bytes = update_service::download_update_with_progress(&state.http_client, &url, &app)
         .await

--- a/src-tauri/src/services/update_service.rs
+++ b/src-tauri/src/services/update_service.rs
@@ -87,6 +87,99 @@ async fn ensure_proxy_resolved(client: &reqwest::Client) {
     let _ = PROXY_CACHE.set(None);
 }
 
+/// Measure how fast `url` actually delivers bytes, by pulling the first slice of
+/// the real asset. Returns bytes/sec, or `None` if it never produced any data.
+///
+/// Reachability and throughput are different questions: a mirror can answer a
+/// HEAD instantly and then trickle the file. This asks the question that
+/// matters, on the file being downloaded.
+async fn measure_speed(client: &reqwest::Client, url: &str) -> Option<u64> {
+    use futures_util::StreamExt;
+
+    /// Enough of the file to see past connection setup, small enough that
+    /// probing every mirror stays cheap.
+    const PROBE_BYTES: u64 = 384 * 1024;
+    const PROBE_LIMIT: std::time::Duration = std::time::Duration::from_secs(4);
+
+    let started = std::time::Instant::now();
+    let response = client
+        .get(url)
+        .header("User-Agent", "MapleLink-Updater")
+        // Mirrors that ignore Range just start sending the whole file; the read
+        // loop below stops either way.
+        .header("Range", format!("bytes=0-{}", PROBE_BYTES - 1))
+        .timeout(PROBE_LIMIT)
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+
+    let mut got: u64 = 0;
+    let mut stream = response.bytes_stream();
+    // On timeout the read future is dropped and `got` keeps whatever arrived, so
+    // a slow mirror still scores rather than being discarded.
+    let _ = tokio::time::timeout(PROBE_LIMIT, async {
+        while let Some(Ok(chunk)) = stream.next().await {
+            got += chunk.len() as u64;
+            if got >= PROBE_BYTES {
+                break;
+            }
+        }
+    })
+    .await;
+
+    let secs = started.elapsed().as_secs_f64();
+    (got > 0 && secs > 0.0).then(|| (got as f64 / secs) as u64)
+}
+
+/// Pick the fastest way to fetch `url`, by racing the candidates against each
+/// other on the actual file.
+///
+/// Mirror speed swings by the hour, so the mirror that answered a probe at
+/// startup is no guide to which one will serve the download now. `direct_too`
+/// adds GitHub itself to the race — left out when the user explicitly asked for
+/// a proxy.
+pub async fn fastest_download_url(client: &reqwest::Client, url: &str, direct_too: bool) -> String {
+    let mut candidates: Vec<String> = Vec::new();
+    if direct_too {
+        candidates.push(url.to_string());
+    }
+    candidates.extend(PROXY_MIRRORS.iter().map(|m| format!("{m}{url}")));
+
+    let measured = futures_util::future::join_all(
+        candidates
+            .iter()
+            .map(|c| async move { (c.clone(), measure_speed(client, c).await) }),
+    )
+    .await;
+
+    let mut best: Option<(String, u64)> = None;
+    for (candidate, speed) in measured {
+        match speed {
+            Some(bps) => {
+                tracing::info!("mirror probe: {} KB/s — {candidate}", bps / 1024);
+                if best.as_ref().is_none_or(|(_, b)| bps > *b) {
+                    best = Some((candidate, bps));
+                }
+            }
+            None => tracing::debug!("mirror probe: no response — {candidate}"),
+        }
+    }
+
+    match best {
+        Some((candidate, bps)) => {
+            tracing::info!("downloading via the fastest route ({} KB/s)", bps / 1024);
+            candidate
+        }
+        None => {
+            tracing::warn!("no candidate responded to the speed probe; using the default route");
+            maybe_proxy_url(url)
+        }
+    }
+}
+
 /// Apply proxy prefix to a URL if needed.
 fn maybe_proxy_url(url: &str) -> String {
     match PROXY_CACHE.get() {

--- a/src/features/shared/UpdateDialog.tsx
+++ b/src/features/shared/UpdateDialog.tsx
@@ -28,6 +28,9 @@ export function UpdateDialog({ update, onClose }: Props) {
   const store = useUpdateStore();
   const [needsProxy, setNeedsProxy] = useState(false);
   const [useProxy, setUseProxy] = useState(false);
+  // The speed race runs before the first byte arrives, so say so — otherwise
+  // the bar sits at zero for a few seconds and reads as a hang.
+  const [probing, setProbing] = useState(false);
   const [probeComplete, setProbeComplete] = useState(false);
 
   const isDownloading = store.status === "downloading";
@@ -53,11 +56,14 @@ export function UpdateDialog({ update, onClose }: Props) {
     const unlisten = listen<{ downloaded: number; total: number; speed: number }>(
       "update-download-progress",
       (event) => {
+        setProbing(false);
         store.updateProgress(event.payload.downloaded, event.payload.total, event.payload.speed);
       },
     );
+    const unlistenProbe = listen("update-probing-mirrors", () => setProbing(true));
     return () => {
       unlisten.then((f) => f());
+      unlistenProbe.then((f) => f());
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -136,13 +142,19 @@ export function UpdateDialog({ update, onClose }: Props) {
               />
             </div>
             <div className="flex items-center justify-between text-[11px] text-text-dim">
-              <span>
-                {formatBytes(store.downloaded)}
-                {store.total > 0 ? ` / ${formatBytes(store.total)}` : ""}
-                {" · "}
-                {percent}%
-              </span>
-              <span>{formatSpeed(store.speed)}</span>
+              {probing && store.downloaded === 0 ? (
+                <span>{t("update.probing_mirrors")}</span>
+              ) : (
+                <>
+                  <span>
+                    {formatBytes(store.downloaded)}
+                    {store.total > 0 ? ` / ${formatBytes(store.total)}` : ""}
+                    {" · "}
+                    {percent}%
+                  </span>
+                  <span>{formatSpeed(store.speed)}</span>
+                </>
+              )}
             </div>
             <div className="text-[10px] text-text-faint">
               {t("update.method")}:{" "}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -453,5 +453,6 @@
   "onboarding.captcha_body": "Whether a bot check appears depends on your network's score\nThe app can't control that\nMapleLink is third-party, so some antivirus flags it\nJudge for yourself whether to use it",
   "announcement.hide_banner": "Hide this announcement banner",
   "toolbox.tabs.announcements": "Announcements",
-  "toolbox.announcements.empty": "No announcements yet"
+  "toolbox.announcements.empty": "No announcements yet",
+  "update.probing_mirrors": "Testing download speeds…"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -453,5 +453,6 @@
   "onboarding.captcha_body": "会不会跳验证，取决于你当下的网络环境分数\n这不是程序能控制的\n本程序是第三方登录器，部分杀毒会误判\n请自行评估是否使用",
   "announcement.hide_banner": "不再显示这条公告横幅",
   "toolbox.tabs.announcements": "公告",
-  "toolbox.announcements.empty": "暂时没有公告"
+  "toolbox.announcements.empty": "暂时没有公告",
+  "update.probing_mirrors": "正在测试下载速度…"
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -453,5 +453,6 @@
   "onboarding.captcha_body": "會不會跳驗證，取決於你當下的網路環境分數\n這不是程式能控制的\n本程式是第三方登入器，部分防毒會誤判\n請自行評估是否使用",
   "announcement.hide_banner": "不再顯示這條公告橫幅",
   "toolbox.tabs.announcements": "公告",
-  "toolbox.announcements.empty": "暫時沒有公告"
+  "toolbox.announcements.empty": "暫時沒有公告",
+  "update.probing_mirrors": "正在測試下載速度…"
 }


### PR DESCRIPTION
## Problem

Users report ghproxy being fast some days and slow others. The cause is that the picker never asked about speed — `ensure_proxy_resolved` walks `PROXY_MIRRORS` in order, sends a `HEAD` to `api.github.com` through each, and takes the first that answers. That result is then cached in a `OnceLock` for the rest of the session.

Answering a HEAD instantly and then trickling a 22MB file are entirely compatible. So whichever mirror happened to be listed first and reachable won every time, regardless of what it would actually deliver.

## Fix

Measure it. Immediately before the download, `fastest_download_url` pulls the first 384KB of the **actual asset** from every candidate concurrently and keeps whichever delivered the most bytes per second.

- All four mirrors race, plus GitHub direct — unless the user ticked the proxy box, which keeps direct out of it.
- Capped at 4 seconds; candidates run in parallel, so that's the total, not per-mirror.
- A mirror that ignores `Range` just starts sending the whole file; the read loop stops at 384KB either way.
- On timeout the partial byte count still scores, so a slow mirror ranks low rather than being discarded outright.
- Every candidate's measured speed is logged, so a user report comes with the numbers.

The startup reachability probe is untouched — it answers whether a proxy is needed at all; this answers which one.

## Interface

The race runs before the first byte arrives, so the dialog shows "正在測試下載速度…" during it. Otherwise the progress bar sits at zero for a few seconds and reads as a hang.

## Cost

~1.9MB of probe traffic across five candidates, once per download, against a 22MB file. Worth it to avoid picking a mirror that delivers at a fraction of the best one's rate.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (105 passed), `tsc`, `eslint`, `prettier --check`, i18n parity — all green.

## Worth a reviewer's attention

Can't be verified from here — it needs someone on a connection where the mirrors actually differ. The log lines (`mirror probe: N KB/s — <url>`) are there to confirm it picks sensibly in the field.