### PR TITLE
chore(deps): patch postcss path traversal, and brace-expansion DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplelink",
-  "version": "0.3.13",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplelink",
-      "version": "0.3.13",
+      "version": "0.4.6",
       "dependencies": {
         "@tanstack/react-query": "^5.99.2",
         "@tauri-apps/api": "^2.11.0",
@@ -1707,16 +1707,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2748,9 +2748,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2892,9 +2892,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2912,7 +2912,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Closes the open Dependabot alert (#14).

## postcss — GHSA-r28c-9q8g-f849 (high)

Versions ≤ 8.5.17 resolve a stylesheet's `sourceMappingURL` without containing it to the source tree, so a crafted `/*# sourceMappingURL=../../... */` makes the build read and disclose an arbitrary `.map` file.

It reaches us through `vite`. **8.5.16 → 8.5.23** carries the fix (8.5.18 is the first patched release) and brings `nanoid` 3.3.15 → 3.3.16 with it.

Reachability here is limited — it's a build-time transform over our own stylesheets, not something a user's input flows into — but it's a one-line lockfile move.

## brace-expansion — GHSA-mh99-v99m-4gvg (high)

Surfaced by `npm audit`, not by Dependabot. Reachable only through `eslint → minimatch`, so it never ships in a build; patched anyway at 5.0.7 → 5.0.8 since it costs nothing. That release requires Node 20, and both workflows pin Node 22.

## Scope

Lockfile only — no dependency ranges in `package.json` changed. Four entries move, all patch-level:

| Package | | Why |
|---|---|---|
| postcss | 8.5.16 → 8.5.23 | the advisory |
| nanoid | 3.3.15 → 3.3.16 | postcss's dependency |
| brace-expansion | 5.0.7 → 5.0.8 | the audit finding |
| *(lockfile `version` field)* | 0.3.13 → 0.4.6 | was stale against package.json; npm corrected it |

`npm audit` now reports 0 vulnerabilities.

## Checks

`tsc`, `eslint`, `prettier --check`, `vitest` (3 passed), `npm run build` — all green. eslint runs on the updated brace-expansion without complaint.