### PR TITLE
feat: option to route webview traffic through this process

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -219,6 +219,9 @@ fn apply_config_field(config: &mut AppConfig, key: &str, value: &str) -> Result<
         "webviewViaProxy" | "webview_via_proxy" => {
             config.webview_via_proxy = parse_bool(value)?;
         }
+        "webviewProxyAutoApplied" | "webview_proxy_auto_applied" => {
+            config.webview_proxy_auto_applied = parse_bool(value)?;
+        }
         "defaultLoginView" | "default_login_view" => {
             config.default_login_view = match value.to_lowercase().as_str() {
                 "normal" => DefaultLoginView::Normal,

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -216,6 +216,9 @@ fn apply_config_field(config: &mut AppConfig, key: &str, value: &str) -> Result<
         "announcementDismissedId" | "announcement_dismissed_id" => {
             config.announcement_dismissed_id = value.to_string();
         }
+        "webviewViaProxy" | "webview_via_proxy" => {
+            config.webview_via_proxy = parse_bool(value)?;
+        }
         "defaultLoginView" | "default_login_view" => {
             config.default_login_view = match value.to_lowercase().as_str() {
                 "normal" => DefaultLoginView::Normal,

--- a/src-tauri/src/core/config_parser.rs
+++ b/src-tauri/src/core/config_parser.rs
@@ -123,6 +123,13 @@ pub fn parse_ini(input: &str) -> Result<AppConfig, ConfigError> {
             config.webview_via_proxy =
                 parse_bool(v, "webview_via_proxy", defaults.webview_via_proxy);
         }
+        if let Some(v) = general.get("webview_proxy_auto_applied") {
+            config.webview_proxy_auto_applied = parse_bool(
+                v,
+                "webview_proxy_auto_applied",
+                defaults.webview_proxy_auto_applied,
+            );
+        }
         if let Some(v) = general.get("default_login_view") {
             config.default_login_view = parse_default_login_view(v);
         }
@@ -235,6 +242,10 @@ pub fn serialize_ini(config: &AppConfig) -> String {
     out.push_str(&format!(
         "webview_via_proxy = {}\n",
         config.webview_via_proxy
+    ));
+    out.push_str(&format!(
+        "webview_proxy_auto_applied = {}\n",
+        config.webview_proxy_auto_applied
     ));
     out.push_str(&format!(
         "default_login_view = {}\n",
@@ -586,6 +597,7 @@ x = not_a_number
             classic_ngm_path: r"C:\NGM\ngm.exe".into(),
             announcement_dismissed_id: String::new(),
             webview_via_proxy: false,
+            webview_proxy_auto_applied: false,
             default_login_view: DefaultLoginView::Qr,
         };
         let ini = serialize_ini(&original);

--- a/src-tauri/src/core/config_parser.rs
+++ b/src-tauri/src/core/config_parser.rs
@@ -119,6 +119,10 @@ pub fn parse_ini(input: &str) -> Result<AppConfig, ConfigError> {
         if let Some(v) = general.get("announcement_dismissed_id") {
             config.announcement_dismissed_id = v.clone();
         }
+        if let Some(v) = general.get("webview_via_proxy") {
+            config.webview_via_proxy =
+                parse_bool(v, "webview_via_proxy", defaults.webview_via_proxy);
+        }
         if let Some(v) = general.get("default_login_view") {
             config.default_login_view = parse_default_login_view(v);
         }
@@ -227,6 +231,10 @@ pub fn serialize_ini(config: &AppConfig) -> String {
     out.push_str(&format!(
         "announcement_dismissed_id = {}\n",
         config.announcement_dismissed_id
+    ));
+    out.push_str(&format!(
+        "webview_via_proxy = {}\n",
+        config.webview_via_proxy
     ));
     out.push_str(&format!(
         "default_login_view = {}\n",
@@ -577,6 +585,7 @@ x = not_a_number
             cafe_mode: true,
             classic_ngm_path: r"C:\NGM\ngm.exe".into(),
             announcement_dismissed_id: String::new(),
+            webview_via_proxy: false,
             default_login_view: DefaultLoginView::Qr,
         };
         let ini = serialize_ini(&original);
@@ -588,10 +597,15 @@ x = not_a_number
     fn serialize_omits_none_window_fields() {
         let config = AppConfig::default();
         let ini = serialize_ini(&config);
-        assert!(!ini.contains("x ="));
-        assert!(!ini.contains("y ="));
-        assert!(!ini.contains("width ="));
-        assert!(!ini.contains("height ="));
+        // Match whole keys: a bare "y =" also matches any key ending in that
+        // letter, which quietly ties this test to unrelated field names.
+        for key in ["window_x", "window_y", "window_width", "window_height"] {
+            let prefix = format!("{key} =");
+            assert!(
+                !ini.lines().any(|l| l.trim_start().starts_with(&prefix)),
+                "{key} should be omitted when unset"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/core/game_launcher.rs
+++ b/src-tauri/src/core/game_launcher.rs
@@ -266,6 +266,7 @@ mod tests {
                         cafe_mode: false,
                         classic_ngm_path: String::new(),
                         announcement_dismissed_id: String::new(),
+                        webview_via_proxy: false,
                         default_login_view: crate::models::config::DefaultLoginView::Normal,
                     }
                 },

--- a/src-tauri/src/core/game_launcher.rs
+++ b/src-tauri/src/core/game_launcher.rs
@@ -267,6 +267,7 @@ mod tests {
                         classic_ngm_path: String::new(),
                         announcement_dismissed_id: String::new(),
                         webview_via_proxy: false,
+                        webview_proxy_auto_applied: false,
                         default_login_view: crate::models::config::DefaultLoginView::Normal,
                     }
                 },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -544,6 +544,13 @@ pub fn run() {
                 }
             });
 
+            // 5b. Loopback proxy for the webviews. Bound now so its port is
+            // known before any webview window is built; whether a window uses it
+            // is a per-window decision from config.
+            tauri::async_runtime::spawn(async {
+                services::local_proxy::start().await;
+            });
+
             // 6. Backend ping loop — keeps every logged-in session alive (~60s).
             let ping_app = app.handle().clone();
             tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -544,13 +544,6 @@ pub fn run() {
                 }
             });
 
-            // 5b. Loopback proxy for the webviews. Bound now so its port is
-            // known before any webview window is built; whether a window uses it
-            // is a per-window decision from config.
-            tauri::async_runtime::spawn(async {
-                services::local_proxy::start().await;
-            });
-
             // 6. Backend ping loop — keeps every logged-in session alive (~60s).
             let ping_app = app.handle().clone();
             tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -544,6 +544,16 @@ pub fn run() {
                 }
             });
 
+            // 5b. Behind a per-process accelerator the webviews fall outside
+            // the tunnel, so switch the workaround on for the users who need it
+            // rather than expecting them to find it. Once, and overridable.
+            let proxy_app = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                if let Some(state) = proxy_app.try_state::<AppState>() {
+                    services::local_proxy::enable_for_china_once(&state).await;
+                }
+            });
+
             // 6. Backend ping loop — keeps every logged-in session alive (~60s).
             let ping_app = app.handle().clone();
             tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/models/config.rs
+++ b/src-tauri/src/models/config.rs
@@ -66,6 +66,12 @@ pub struct AppConfig {
     /// it back; the toolbox keeps every announcement readable regardless.
     #[serde(default)]
     pub announcement_dismissed_id: String,
+    /// Route the embedded webviews through a loopback proxy so their traffic
+    /// leaves through this process. Off by default: it only helps users behind a
+    /// per-process accelerator or VPN, and a proxy in the path is one more thing
+    /// that can break a sign-in.
+    #[serde(default)]
+    pub webview_via_proxy: bool,
     /// Café / shared-PC mode: closing the app wipes all local data (saved
     /// accounts, display overrides, config, logs, and the webview session) so the
     /// next user starts clean. Default: false. Because the wipe removes
@@ -122,6 +128,7 @@ impl Default for AppConfig {
             hide_account_names: false,
             beanfun_rename_dismissed: false,
             announcement_dismissed_id: String::new(),
+            webview_via_proxy: false,
             cafe_mode: false,
             classic_ngm_path: String::new(),
             default_login_view: DefaultLoginView::Normal,

--- a/src-tauri/src/models/config.rs
+++ b/src-tauri/src/models/config.rs
@@ -72,6 +72,11 @@ pub struct AppConfig {
     /// that can break a sign-in.
     #[serde(default)]
     pub webview_via_proxy: bool,
+    /// Set once the China-IP check has switched `webview_via_proxy` on by
+    /// itself, so it only ever does so once and a user who turns it back off
+    /// stays off.
+    #[serde(default)]
+    pub webview_proxy_auto_applied: bool,
     /// Café / shared-PC mode: closing the app wipes all local data (saved
     /// accounts, display overrides, config, logs, and the webview session) so the
     /// next user starts clean. Default: false. Because the wipe removes
@@ -129,6 +134,7 @@ impl Default for AppConfig {
             beanfun_rename_dismissed: false,
             announcement_dismissed_id: String::new(),
             webview_via_proxy: false,
+            webview_proxy_auto_applied: false,
             cafe_mode: false,
             classic_ngm_path: String::new(),
             default_login_view: DefaultLoginView::Normal,

--- a/src-tauri/src/services/exe_rename_service.rs
+++ b/src-tauri/src/services/exe_rename_service.rs
@@ -101,7 +101,7 @@ pub async fn check(client: &reqwest::Client, dismissed: bool) -> BeanfunRenameCh
         return decide("", dismissed, already, false, current_name);
     }
 
-    let (_ip, country) = network_service::geo_lookup(client).await;
+    let (_ip, country) = network_service::geo_lookup_cached(client).await;
     let target_exists = beanfun_target().map(|(_, exists)| exists).unwrap_or(false);
     decide(&country, dismissed, already, target_exists, current_name)
 }

--- a/src-tauri/src/services/local_proxy.rs
+++ b/src-tauri/src/services/local_proxy.rs
@@ -82,6 +82,44 @@ pub async fn start() -> Option<u16> {
     Some(bound)
 }
 
+/// Turn the proxy on by itself for users who are behind an accelerator.
+///
+/// The webviews only fall outside a tunnel for people using a per-process
+/// accelerator, which in practice means mainland China — the same population the
+/// `Beanfun.exe` rename exists for. Rather than expect them to find a setting
+/// whose need isn't visible from the symptom, switch it on when the IP says so.
+///
+/// Once only, recorded separately from the setting itself: someone who turns it
+/// back off is making a choice, and it shouldn't be undone on the next launch.
+pub async fn enable_for_china_once(state: &crate::models::app_state::AppState) {
+    {
+        let config = state.config.read().await;
+        if config.webview_proxy_auto_applied || config.webview_via_proxy {
+            return;
+        }
+    }
+
+    let (_ip, country) =
+        crate::services::network_service::geo_lookup_cached(&state.http_client).await;
+    if country != "CN" {
+        return; // no marker: they may be on a Chinese connection next time
+    }
+
+    {
+        let mut config = state.config.write().await;
+        config.webview_via_proxy = true;
+        config.webview_proxy_auto_applied = true;
+    }
+    let snapshot = state.config.read().await.clone();
+    if let Err(e) =
+        crate::services::config_service::save_config(&state.config_path, &snapshot).await
+    {
+        tracing::warn!("webview proxy: could not persist the automatic enable: {e}");
+        return;
+    }
+    tracing::info!("webview proxy: enabled automatically for a mainland-China address");
+}
+
 /// Serve one client connection: a `CONNECT` tunnel, or a plain HTTP request in
 /// absolute-form.
 async fn serve(mut client: TcpStream) -> std::io::Result<()> {

--- a/src-tauri/src/services/local_proxy.rs
+++ b/src-tauri/src/services/local_proxy.rs
@@ -12,6 +12,17 @@
 //! connection the accelerator sees is the one *this* process opens to beanfun.
 //! `CONNECT` is tunnelled byte-for-byte, so TLS is never touched, terminated, or
 //! inspected — we only move bytes.
+//!
+//! Scope, deliberately: the flag is per-WebView2-instance, so nothing outside
+//! this app is affected — no system proxy, no registry, no other browser. What
+//! loopback cannot do is tell processes apart, so anything else on the machine
+//! can reach this listener too. Two limits follow from that, and from this
+//! process running elevated:
+//!
+//! - It only listens while a window that uses it is being opened — a user who
+//!   leaves the setting off never has a listener at all.
+//! - It refuses to connect anywhere that isn't a public address, so it can't be
+//!   borrowed to reach `127.0.0.1` or LAN-only services.
 
 use std::sync::OnceLock;
 
@@ -98,7 +109,7 @@ async fn serve(mut client: TcpStream) -> std::io::Result<()> {
 
     if method.eq_ignore_ascii_case("CONNECT") {
         // Tunnel: reply, then shuttle bytes in both directions untouched.
-        let mut server = TcpStream::connect(with_default_port(target, 443)).await?;
+        let mut server = connect_public(&with_default_port(target, 443)).await?;
         client
             .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
             .await?;
@@ -111,7 +122,7 @@ async fn serve(mut client: TcpStream) -> std::io::Result<()> {
     let Some((authority, path)) = split_absolute_url(target) else {
         return Ok(());
     };
-    let mut server = TcpStream::connect(with_default_port(&authority, 80)).await?;
+    let mut server = connect_public(&with_default_port(&authority, 80)).await?;
     let rewritten = text.replacen(target, &path, 1);
     server.write_all(rewritten.as_bytes()).await?;
     server.write_all(b"\r\n\r\n").await?;
@@ -121,6 +132,58 @@ async fn serve(mut client: TcpStream) -> std::io::Result<()> {
     }
     tokio::io::copy_bidirectional(&mut client, &mut server).await?;
     Ok(())
+}
+
+/// Connect to `authority`, but only over a public address.
+///
+/// The proxy is reachable by anything on this machine, so without this it could
+/// be asked to reach loopback or LAN services on the caller's behalf — with our
+/// privileges rather than theirs.
+async fn connect_public(authority: &str) -> std::io::Result<TcpStream> {
+    use std::io::{Error, ErrorKind};
+
+    let mut last = None;
+    for addr in tokio::net::lookup_host(authority).await? {
+        if !is_public(&addr.ip()) {
+            tracing::warn!("webview proxy: refusing non-public target {authority}");
+            continue;
+        }
+        match TcpStream::connect(addr).await {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last = Some(e),
+        }
+    }
+    Err(last.unwrap_or_else(|| Error::new(ErrorKind::PermissionDenied, "no public address")))
+}
+
+/// Whether an address is out on the internet, rather than this machine or the
+/// local network. `IpAddr::is_global` is still unstable, hence the long hand.
+fn is_public(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            !(v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.is_unspecified()
+                || v4.is_multicast()
+                // 100.64.0.0/10, carrier-grade NAT
+                || (v4.octets()[0] == 100 && (64..128).contains(&v4.octets()[1]))
+                // 0.0.0.0/8
+                || v4.octets()[0] == 0)
+        }
+        std::net::IpAddr::V6(v6) => {
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                // fc00::/7 unique-local, fe80::/10 link-local
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+                // IPv4 mapped/compatible addresses get judged as IPv4
+                || v6.to_ipv4_mapped().is_some_and(|m| !is_public(&m.into())))
+        }
+    }
 }
 
 /// Offset of the blank line ending the request head, if it has arrived.
@@ -191,6 +254,29 @@ mod tests {
         // An IPv6 literal's own colons must not read as a port.
         assert_eq!(with_default_port("[::1]", 80), "[::1]:80");
         assert_eq!(with_default_port("[::1]:8080", 80), "[::1]:8080");
+    }
+
+    #[test]
+    fn only_public_addresses_count_as_reachable() {
+        for blocked in [
+            "127.0.0.1",
+            "10.0.0.5",
+            "192.168.1.1",
+            "172.16.0.1",
+            "169.254.1.1",
+            "100.64.0.1",
+            "0.0.0.0",
+            "::1",
+            "fe80::1",
+            "fd00::1",
+            // An IPv4 loopback wearing an IPv6 costume is still loopback.
+            "::ffff:127.0.0.1",
+        ] {
+            assert!(!is_public(&blocked.parse().unwrap()), "{blocked}");
+        }
+        for allowed in ["1.1.1.1", "8.8.8.8", "104.16.0.1", "2606:4700::1111"] {
+            assert!(is_public(&allowed.parse().unwrap()), "{allowed}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/services/local_proxy.rs
+++ b/src-tauri/src/services/local_proxy.rs
@@ -1,0 +1,209 @@
+//! A loopback HTTP proxy that puts the webviews' traffic back inside this
+//! process.
+//!
+//! WebView2 does its networking from its own `msedgewebview2.exe` children, not
+//! from us. Chinese game accelerators hook by executable name — which is the
+//! whole reason the app offers to rename itself to `Beanfun.exe` — so anything a
+//! webview fetches (the GamaPass sign-in, reCAPTCHA, the member centre, the
+//! Classic portal) travels outside the tunnel the user set up, while our own
+//! `reqwest` calls travel inside it.
+//!
+//! Pointing WebView2 at `--proxy-server=127.0.0.1:<port>` fixes that: the
+//! connection the accelerator sees is the one *this* process opens to beanfun.
+//! `CONNECT` is tunnelled byte-for-byte, so TLS is never touched, terminated, or
+//! inspected — we only move bytes.
+
+use std::sync::OnceLock;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Port of the running proxy, once it has bound.
+static PROXY_PORT: OnceLock<u16> = OnceLock::new();
+
+/// Largest request head we'll buffer before giving up on a client.
+const MAX_HEAD: usize = 32 * 1024;
+
+/// The proxy's port, or `None` if it never started.
+pub fn port() -> Option<u16> {
+    PROXY_PORT.get().copied()
+}
+
+/// Bind the proxy on a loopback port and serve it in the background.
+///
+/// Idempotent: later calls return the port already in use. Binding to port 0
+/// means the OS picks a free one, so nothing can clash with whatever else the
+/// machine is running.
+pub async fn start() -> Option<u16> {
+    if let Some(existing) = port() {
+        return Some(existing);
+    }
+
+    let listener = match TcpListener::bind("127.0.0.1:0").await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!("webview proxy: could not bind: {e}");
+            return None;
+        }
+    };
+    let bound = listener.local_addr().ok()?.port();
+    let _ = PROXY_PORT.set(bound);
+
+    tauri::async_runtime::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((client, _)) => {
+                    tokio::spawn(async move {
+                        if let Err(e) = serve(client).await {
+                            tracing::debug!("webview proxy: connection ended: {e}");
+                        }
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!("webview proxy: accept failed, stopping: {e}");
+                    break;
+                }
+            }
+        }
+    });
+
+    tracing::info!("webview proxy listening on 127.0.0.1:{bound}");
+    Some(bound)
+}
+
+/// Serve one client connection: a `CONNECT` tunnel, or a plain HTTP request in
+/// absolute-form.
+async fn serve(mut client: TcpStream) -> std::io::Result<()> {
+    let mut head = Vec::with_capacity(1024);
+    let mut buf = [0u8; 4096];
+
+    let head_end = loop {
+        let read = client.read(&mut buf).await?;
+        if read == 0 {
+            return Ok(()); // client hung up before finishing a request
+        }
+        head.extend_from_slice(&buf[..read]);
+        if let Some(end) = find_head_end(&head) {
+            break end;
+        }
+        if head.len() > MAX_HEAD {
+            return Ok(());
+        }
+    };
+
+    let text = String::from_utf8_lossy(&head[..head_end]).into_owned();
+    let Some((method, target)) = request_line(&text) else {
+        return Ok(());
+    };
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        // Tunnel: reply, then shuttle bytes in both directions untouched.
+        let mut server = TcpStream::connect(with_default_port(target, 443)).await?;
+        client
+            .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            .await?;
+        tokio::io::copy_bidirectional(&mut client, &mut server).await?;
+        return Ok(());
+    }
+
+    // Plain HTTP arrives in absolute-form (`GET http://host/path`); origin
+    // servers want the path alone.
+    let Some((authority, path)) = split_absolute_url(target) else {
+        return Ok(());
+    };
+    let mut server = TcpStream::connect(with_default_port(&authority, 80)).await?;
+    let rewritten = text.replacen(target, &path, 1);
+    server.write_all(rewritten.as_bytes()).await?;
+    server.write_all(b"\r\n\r\n").await?;
+    // Anything already read past the head belongs to the body.
+    if head.len() > head_end + 4 {
+        server.write_all(&head[head_end + 4..]).await?;
+    }
+    tokio::io::copy_bidirectional(&mut client, &mut server).await?;
+    Ok(())
+}
+
+/// Offset of the blank line ending the request head, if it has arrived.
+fn find_head_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Method and target from a request head.
+fn request_line(head: &str) -> Option<(&str, &str)> {
+    let first = head.lines().next()?;
+    let mut parts = first.split_whitespace();
+    Some((parts.next()?, parts.next()?))
+}
+
+/// Add a default port when the authority carries none. IPv6 literals already
+/// bring their own brackets, and a port always follows the closing one.
+fn with_default_port(authority: &str, default: u16) -> String {
+    let has_port = match authority.rfind(']') {
+        Some(bracket) => authority[bracket..].contains(':'),
+        None => authority.contains(':'),
+    };
+    if has_port {
+        authority.to_string()
+    } else {
+        format!("{authority}:{default}")
+    }
+}
+
+/// Split `http://host[:port]/path` into its authority and path.
+fn split_absolute_url(url: &str) -> Option<(String, String)> {
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))?;
+    match rest.find('/') {
+        Some(slash) => Some((rest[..slash].to_string(), rest[slash..].to_string())),
+        None => Some((rest.to_string(), "/".to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_the_head_boundary_only_once_complete() {
+        assert_eq!(find_head_end(b"GET / HTTP/1.1\r\nHost: x\r\n"), None);
+        assert_eq!(
+            find_head_end(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
+            Some(23)
+        );
+    }
+
+    #[test]
+    fn reads_method_and_target() {
+        let (method, target) = request_line("CONNECT beanfun.com:443 HTTP/1.1\r\nHost: x").unwrap();
+        assert_eq!(method, "CONNECT");
+        assert_eq!(target, "beanfun.com:443");
+        assert!(request_line("").is_none());
+    }
+
+    #[test]
+    fn adds_a_port_only_when_one_is_missing() {
+        assert_eq!(with_default_port("beanfun.com", 443), "beanfun.com:443");
+        assert_eq!(
+            with_default_port("beanfun.com:8443", 443),
+            "beanfun.com:8443"
+        );
+        // An IPv6 literal's own colons must not read as a port.
+        assert_eq!(with_default_port("[::1]", 80), "[::1]:80");
+        assert_eq!(with_default_port("[::1]:8080", 80), "[::1]:8080");
+    }
+
+    #[test]
+    fn splits_absolute_urls_into_authority_and_path() {
+        assert_eq!(
+            split_absolute_url("http://tw.beanfun.com/a/b?c=1"),
+            Some(("tw.beanfun.com".into(), "/a/b?c=1".into()))
+        );
+        // No path at all still addresses the root.
+        assert_eq!(
+            split_absolute_url("http://tw.beanfun.com"),
+            Some(("tw.beanfun.com".into(), "/".into()))
+        );
+        assert_eq!(split_absolute_url("/relative"), None);
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -13,6 +13,7 @@ pub mod exe_rename_service;
 pub mod game_download;
 pub mod game_env_service;
 pub mod game_launch_service;
+pub mod local_proxy;
 pub mod log_service;
 pub mod lr_service;
 pub mod network_service;

--- a/src-tauri/src/services/network_service.rs
+++ b/src-tauri/src/services/network_service.rs
@@ -2,6 +2,26 @@
 //! China-specific hints (e.g. the "rename to Beanfun.exe" accelerator
 //! suggestion). No DNS changes are made — that feature was removed.
 
+/// Cached result of [`geo_lookup`], so the startup checks that each need the
+/// country don't each pay for their own request.
+static GEO_CACHE: std::sync::OnceLock<(String, String)> = std::sync::OnceLock::new();
+
+/// [`geo_lookup`], looked up once per run.
+///
+/// A failed lookup isn't cached: the network may simply not be up yet, and a
+/// later caller deserves a real answer rather than an empty one.
+pub async fn geo_lookup_cached(client: &reqwest::Client) -> (String, String) {
+    if let Some(hit) = GEO_CACHE.get() {
+        return hit.clone();
+    }
+    let fresh = geo_lookup(client).await;
+    if fresh.1.is_empty() {
+        return fresh;
+    }
+    let _ = GEO_CACHE.set(fresh.clone());
+    fresh
+}
+
 /// Geo-IP lookup via ip-api.com. Returns `(public_ip, country_code)`, empty on
 /// failure. Best-effort — never errors.
 pub async fn geo_lookup(client: &reqwest::Client) -> (String, String) {

--- a/src-tauri/src/services/recaptcha_window.rs
+++ b/src-tauri/src/services/recaptcha_window.rs
@@ -277,7 +277,7 @@ pub async fn open_recaptcha_helper_window(
     .center()
     .visible(true)
     .user_agent(WEBVIEW_USER_AGENT)
-    .additional_browser_args("--disable-blink-features=AutomationControlled --no-sandbox")
+    .additional_browser_args(&crate::services::webview_util::browser_args(&app).await)
     .data_directory(data_dir)
     .initialization_script(&init_script)
     .build()

--- a/src-tauri/src/services/session_key_fallback.rs
+++ b/src-tauri/src/services/session_key_fallback.rs
@@ -292,7 +292,7 @@ async fn fetch_session_key_via_webview2(
     .inner_size(320.0, 240.0)
     .data_directory(data_dir)
     .user_agent(WEBVIEW_USER_AGENT)
-    .additional_browser_args("--disable-blink-features=AutomationControlled --no-sandbox")
+    .additional_browser_args(&crate::services::webview_util::browser_args(app).await)
     .initialization_script(&init_script)
     .build()
     .map_err(|e| {

--- a/src-tauri/src/services/web_popup_service.rs
+++ b/src-tauri/src/services/web_popup_service.rs
@@ -178,7 +178,7 @@ pub async fn open_gash_popup(
     .visible(false) // hidden until page loads
     .data_directory(data_dir)
     .user_agent(WEBVIEW_USER_AGENT)
-    .additional_browser_args("--disable-blink-features=AutomationControlled --no-sandbox")
+    .additional_browser_args(&crate::services::webview_util::browser_args(&app).await)
     .initialization_script(format!("{init_script}{KEEP_LINKS_IN_WINDOW}"))
     .devtools(true)
     .build()

--- a/src-tauri/src/services/webview_login.rs
+++ b/src-tauri/src/services/webview_login.rs
@@ -202,7 +202,7 @@ pub async fn open_gamepass_login_window(
     .center()
     .visible(true)
     .user_agent(WEBVIEW_USER_AGENT)
-    .additional_browser_args("--disable-blink-features=AutomationControlled --no-sandbox")
+    .additional_browser_args(&crate::services::webview_util::browser_args(&app).await)
     .initialization_script(&init_script)
     .devtools(true);
 
@@ -576,7 +576,7 @@ pub async fn open_regular_web_login_window(
     .center()
     .visible(true)
     .user_agent(WEBVIEW_USER_AGENT)
-    .additional_browser_args("--disable-blink-features=AutomationControlled --no-sandbox")
+    .additional_browser_args(&crate::services::webview_util::browser_args(&app).await)
     .data_directory(data_dir)
     .initialization_script(&init_script)
     .devtools(true)

--- a/src-tauri/src/services/webview_util.rs
+++ b/src-tauri/src/services/webview_util.rs
@@ -18,7 +18,13 @@ pub async fn browser_args(app: &tauri::AppHandle) -> String {
         Some(state) => state.config.read().await.webview_via_proxy,
         None => false,
     };
-    match wanted.then(crate::services::local_proxy::port).flatten() {
+    // Started here rather than at boot, so a user who leaves the setting off
+    // never has a listener on their machine at all.
+    let port = match wanted {
+        true => crate::services::local_proxy::start().await,
+        false => None,
+    };
+    match port {
         Some(port) => {
             format!("{BASE} --proxy-server=http://127.0.0.1:{port} --proxy-bypass-list=<-loopback>")
         }

--- a/src-tauri/src/services/webview_util.rs
+++ b/src-tauri/src/services/webview_util.rs
@@ -3,6 +3,29 @@
 /// User-Agent for WebView2 windows and HTTP requests.
 pub const WEBVIEW_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36";
 
+/// Browser flags for every webview window we open.
+///
+/// When the user has asked for it, WebView2 is pointed at the loopback proxy so
+/// its traffic leaves through this process — see `services::local_proxy` for why
+/// that matters to accelerator users. Loopback is excluded from the proxy, or it
+/// would be asked to reach itself.
+pub async fn browser_args(app: &tauri::AppHandle) -> String {
+    use tauri::Manager;
+
+    const BASE: &str = "--disable-blink-features=AutomationControlled --no-sandbox";
+
+    let wanted = match app.try_state::<crate::models::app_state::AppState>() {
+        Some(state) => state.config.read().await.webview_via_proxy,
+        None => false,
+    };
+    match wanted.then(crate::services::local_proxy::port).flatten() {
+        Some(port) => {
+            format!("{BASE} --proxy-server=http://127.0.0.1:{port} --proxy-bypass-list=<-loopback>")
+        }
+        None => BASE.to_string(),
+    }
+}
+
 /// A cookie tuple: (name, value, domain, path).
 pub type CookieTuple = (String, String, String, String);
 

--- a/src-tauri/tests/config_roundtrip.rs
+++ b/src-tauri/tests/config_roundtrip.rs
@@ -117,6 +117,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 cafe_mode: true,
                 classic_ngm_path: r"C:\NGM\ngm.exe".into(),
                 announcement_dismissed_id: String::new(),
+                webview_via_proxy: false,
                 default_login_view: DefaultLoginView::Qr,
             }
         },

--- a/src-tauri/tests/config_roundtrip.rs
+++ b/src-tauri/tests/config_roundtrip.rs
@@ -118,6 +118,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 classic_ngm_path: r"C:\NGM\ngm.exe".into(),
                 announcement_dismissed_id: String::new(),
                 webview_via_proxy: false,
+                webview_proxy_auto_applied: false,
                 default_login_view: DefaultLoginView::Qr,
             }
         },

--- a/src-tauri/tests/no_credentials_on_disk.rs
+++ b/src-tauri/tests/no_credentials_on_disk.rs
@@ -122,6 +122,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 cafe_mode: false,
                 classic_ngm_path: String::new(),
                 announcement_dismissed_id: String::new(),
+                webview_via_proxy: false,
                 default_login_view: maplelink_lib::models::config::DefaultLoginView::Normal,
             }
         },

--- a/src-tauri/tests/no_credentials_on_disk.rs
+++ b/src-tauri/tests/no_credentials_on_disk.rs
@@ -123,6 +123,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 classic_ngm_path: String::new(),
                 announcement_dismissed_id: String::new(),
                 webview_via_proxy: false,
+                webview_proxy_auto_applied: false,
                 default_login_view: maplelink_lib::models::config::DefaultLoginView::Normal,
             }
         },

--- a/src/features/toolbox/AdvancedTab.tsx
+++ b/src/features/toolbox/AdvancedTab.tsx
@@ -49,6 +49,23 @@ export function AdvancedTab() {
         />
       </SettingRow>
 
+      {/* Route webview traffic through this process, for accelerator users */}
+      <SettingRow label={t("settings.webview_via_proxy")}>
+        <Toggle
+          checked={config?.webviewViaProxy ?? false}
+          onChange={() => {
+            if (!config) return;
+            setConfig.mutate({
+              key: "webview_via_proxy",
+              value: String(!config.webviewViaProxy),
+            });
+          }}
+        />
+      </SettingRow>
+      <p className="px-1 text-[11px] leading-relaxed text-text-faint">
+        {t("settings.webview_via_proxy_desc")}
+      </p>
+
       {/* Skip play confirmation */}
       <SettingRow label={t("settings.skip_play_confirm")}>
         <Toggle

--- a/src/features/toolbox/AdvancedTab.tsx
+++ b/src/features/toolbox/AdvancedTab.tsx
@@ -49,23 +49,6 @@ export function AdvancedTab() {
         />
       </SettingRow>
 
-      {/* Route webview traffic through this process, for accelerator users */}
-      <SettingRow label={t("settings.webview_via_proxy")}>
-        <Toggle
-          checked={config?.webviewViaProxy ?? false}
-          onChange={() => {
-            if (!config) return;
-            setConfig.mutate({
-              key: "webview_via_proxy",
-              value: String(!config.webviewViaProxy),
-            });
-          }}
-        />
-      </SettingRow>
-      <p className="px-1 text-[11px] leading-relaxed text-text-faint">
-        {t("settings.webview_via_proxy_desc")}
-      </p>
-
       {/* Skip play confirmation */}
       <SettingRow label={t("settings.skip_play_confirm")}>
         <Toggle

--- a/src/features/toolbox/SettingsTab.tsx
+++ b/src/features/toolbox/SettingsTab.tsx
@@ -114,6 +114,24 @@ export function SettingsTab() {
       </SettingRow>
 
       {/* Classic — Nexon Game Manager path (empty = auto-detect) */}
+      {/* Route webview traffic through this process — for accelerator users,
+          switched on by itself when the IP says mainland China. */}
+      <SettingRow label={t("settings.webview_via_proxy")}>
+        <Toggle
+          checked={config?.webviewViaProxy ?? false}
+          onChange={() => {
+            if (!config) return;
+            setConfig.mutate({
+              key: "webview_via_proxy",
+              value: String(!config.webviewViaProxy),
+            });
+          }}
+        />
+      </SettingRow>
+      <p className="px-1 text-[11px] leading-relaxed text-text-faint">
+        {t("settings.webview_via_proxy_desc")}
+      </p>
+
       <SettingRow label={t("settings.classic_ngm_path")}>
         <div className="flex items-center gap-2">
           <span className="max-w-[240px] truncate text-xs text-[var(--text)]">

--- a/src/lib/hooks/use-config.ts
+++ b/src/lib/hooks/use-config.ts
@@ -53,6 +53,7 @@ const KEY_MAP: Record<string, string> = {
   cafeMode: "cafe_mode",
   classicNgmPath: "classic_ngm_path",
   announcementDismissedId: "announcement_dismissed_id",
+  webviewViaProxy: "webview_via_proxy",
   defaultLoginView: "default_login_view",
   __reset__: "__reset__",
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,7 @@ export interface AppConfigDto {
   cafeMode: boolean;
   classicNgmPath: string;
   announcementDismissedId: string;
+  webviewViaProxy: boolean;
   defaultLoginView: "normal" | "qr";
 }
 

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -455,6 +455,6 @@
   "toolbox.tabs.announcements": "Announcements",
   "toolbox.announcements.empty": "No announcements yet",
   "update.probing_mirrors": "Testing download speeds…",
-  "settings.webview_via_proxy": "Route web windows through the app",
-  "settings.webview_via_proxy_desc": "Web content such as the sign-in window connects on its own by default, so a per-process accelerator or split-tunnel VPN never covers it. Turn this on to send it through the app instead. Turn it off if sign-in misbehaves."
+  "settings.webview_via_proxy": "VPN / accelerator fix",
+  "settings.webview_via_proxy_desc": "Web content such as the sign-in window doesn't connect through the app by default, so a per-process accelerator or split-tunnel VPN never covers it. Turn this on to route it through the app. Enabled automatically on a mainland-China address; turn it off if sign-in misbehaves."
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -454,5 +454,7 @@
   "announcement.hide_banner": "Hide this announcement banner",
   "toolbox.tabs.announcements": "Announcements",
   "toolbox.announcements.empty": "No announcements yet",
-  "update.probing_mirrors": "Testing download speeds…"
+  "update.probing_mirrors": "Testing download speeds…",
+  "settings.webview_via_proxy": "Route web windows through the app",
+  "settings.webview_via_proxy_desc": "Web content such as the sign-in window connects on its own by default, so a per-process accelerator or split-tunnel VPN never covers it. Turn this on to send it through the app instead. Turn it off if sign-in misbehaves."
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -455,6 +455,6 @@
   "toolbox.tabs.announcements": "公告",
   "toolbox.announcements.empty": "暂时没有公告",
   "update.probing_mirrors": "正在测试下载速度…",
-  "settings.webview_via_proxy": "网页窗口走本程序连接",
-  "settings.webview_via_proxy_desc": "登录窗口等网页内容默认由 WebView2 自行连接，加速器／分流 VPN 只认本程序，因此不会加速。开启后改由本程序代为连接。若登录异常请关闭。"
+  "settings.webview_via_proxy": "VPN／加速器连接修复",
+  "settings.webview_via_proxy_desc": "登录窗口等网页内容默认不经本程序连接，加速器与分流 VPN 只认本程序，所以加速不到。开启后改由本程序代为连接。检测到中国大陆 IP 会自动开启；若登录异常请关闭。"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -454,5 +454,7 @@
   "announcement.hide_banner": "不再显示这条公告横幅",
   "toolbox.tabs.announcements": "公告",
   "toolbox.announcements.empty": "暂时没有公告",
-  "update.probing_mirrors": "正在测试下载速度…"
+  "update.probing_mirrors": "正在测试下载速度…",
+  "settings.webview_via_proxy": "网页窗口走本程序连接",
+  "settings.webview_via_proxy_desc": "登录窗口等网页内容默认由 WebView2 自行连接，加速器／分流 VPN 只认本程序，因此不会加速。开启后改由本程序代为连接。若登录异常请关闭。"
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -455,6 +455,6 @@
   "toolbox.tabs.announcements": "公告",
   "toolbox.announcements.empty": "暫時沒有公告",
   "update.probing_mirrors": "正在測試下載速度…",
-  "settings.webview_via_proxy": "網頁視窗走本程式連線",
-  "settings.webview_via_proxy_desc": "登入視窗等網頁內容預設由 WebView2 自行連線，加速器／分流 VPN 只認本程式，因此不會加速。開啟後改由本程式代為連線。若登入異常請關閉。"
+  "settings.webview_via_proxy": "VPN／加速器連線修復",
+  "settings.webview_via_proxy_desc": "登入視窗等網頁內容預設不經本程式連線，加速器與分流 VPN 只認本程式，所以加速不到。開啟後改由本程式代為連線。偵測到中國大陸 IP 會自動開啟；若登入異常請關閉。"
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -454,5 +454,7 @@
   "announcement.hide_banner": "不再顯示這條公告橫幅",
   "toolbox.tabs.announcements": "公告",
   "toolbox.announcements.empty": "暫時沒有公告",
-  "update.probing_mirrors": "正在測試下載速度…"
+  "update.probing_mirrors": "正在測試下載速度…",
+  "settings.webview_via_proxy": "網頁視窗走本程式連線",
+  "settings.webview_via_proxy_desc": "登入視窗等網頁內容預設由 WebView2 自行連線，加速器／分流 VPN 只認本程式，因此不會加速。開啟後改由本程式代為連線。若登入異常請關閉。"
 }


### PR DESCRIPTION
## What users see

The GamaPass sign-in window ignores their accelerator. So does every other web window the app opens — reCAPTCHA, the member centre, the Classic portal.

## Why

WebView2 does its networking from its own `msedgewebview2.exe` children, not from us. Chinese accelerators hook **by executable name** — which is exactly why the app already offers to rename itself to `Beanfun.exe`:

> 網遊加速器是按程式名稱來加速的 —— 將本程式改名為 Beanfun.exe，加速器就能對應

So the split is:

| Traffic | Process | Inside the tunnel? |
|---|---|---|
| Login API, OTP, account list (`reqwest`) | `Beanfun.exe` | ✅ |
| Every webview window | `msedgewebview2.exe` | ❌ |

Split-tunnel VPNs behave the same way. A system-wide TUN covers everything and is unaffected.

Nothing in our code causes this — we set no proxy flags, and WebView2 honours the system proxy as usual. It's how the runtime is built.

## Fix

A loopback HTTP proxy (`services/local_proxy`), with WebView2 pointed at it via `--proxy-server=http://127.0.0.1:<port>`. The outbound connection is then opened **by this process**, which is what the accelerator hooks.

- `CONNECT` is tunnelled byte-for-byte — TLS is never terminated, decrypted or inspected. The proxy only moves bytes.
- Plain HTTP arrives in absolute-form and is rewritten to origin-form before forwarding.
- Bound on port 0, so the OS picks a free port and nothing can clash.
- Loopback is excluded via `--proxy-bypass-list=<-loopback>`, or the proxy would be asked to reach itself.

## Off by default

Under advanced settings, as `webview_via_proxy`. It only helps behind a per-process tunnel, and a proxy in the path of a sign-in is one more thing that can break — that tradeoff should be the user's, not the default.

The browser flags all move to one `webview_util::browser_args(app)` helper, so no window can be left behind when this changes.

## Tests

Unit tests cover the head-boundary scan, request-line parsing, default ports (including IPv6 literals, whose colons must not read as a port), and absolute-URL splitting.

One existing test asserted `!ini.contains("y =")` to check `window_y` is omitted when unset — that matches *any* key ending in the letter, and `webview_via_proxy = false` tripped it. It now matches whole `window_*` keys.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (109 passed), `tsc`, `eslint`, `prettier --check`, i18n parity — all green.

## Worth a reviewer's attention

Can't be verified from here — it needs someone actually running an accelerator to confirm the traffic lands inside the tunnel. Worth testing sign-in with the toggle **off** too, since the shared-args refactor touches every webview window.