### PR TITLE
chore(deps): patch two quick-xml DoS advisories, and two npm ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplelink",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplelink",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@tanstack/react-query": "^5.99.2",
         "@tauri-apps/api": "^2.11.0",
@@ -1707,9 +1707,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2748,9 +2748,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2730,9 +2730,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2930,9 +2930,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
Routine audit sweep — both ecosystems now report clean.

## Rust — quick-xml (2 × high, 7.5)

`quick-xml 0.39.4` carries two denial-of-service advisories:

| ID | Issue |
|---|---|
| RUSTSEC-2026-0194 | Quadratic run time checking a start tag for duplicate attribute names |
| RUSTSEC-2026-0195 | Unbounded namespace-declaration allocation in `NsReader` → memory exhaustion |

Both are fixed in 0.41. It reaches us through `plist`, and `plist 1.9` pins `0.39`, so `cargo update -p quick-xml` alone couldn't move it. `plist 1.10` takes `0.41`, so bumping that carries the fix.

`plist` and `quick-xml` are **the only two entries that move** — verified against the lockfile diff. Worth stating explicitly: a blanket `cargo update` in this repo has previously pulled an unrelated crate *backwards* (`windows-core` 0.62 → 0.56, via a range constraint), so the change is kept surgical and checked.

Reachability is low — `plist` is used by `tauri-utils` for bundle metadata, not for anything a user's input flows into — but it's a lockfile-only move.

## npm (2 × high)

| Package | | Advisory |
|---|---|---|
| brace-expansion | 5.0.8 → 5.0.9 | GHSA-rgw5-rvv9-x895 — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
| nanoid | 3.3.16 → 3.3.18 | GHSA-2v37-7h3g-55p8 — custom generators loop indefinitely when size is zero |

Both build-time only: `eslint → minimatch` reaches the first, `vite → postcss` the second. Neither ships in a build.

## Scope

Lockfiles only. No dependency ranges in `package.json` or `Cargo.toml` changed.

## Checks

`cargo audit` (558 crates, clean), `npm audit` (0 vulnerabilities), `cargo build --locked`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (110 passed), `tsc`, `eslint`, `prettier --check`, `vitest`, `npm run build` — all green.