### PR TITLE
perf(build): halve the shipped binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@tanstack/react-query": "^5.99.2",
         "@tauri-apps/api": "^2.11.0",
-        "@tauri-apps/plugin-shell": "^2.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "zustand": "^5.0.0"
@@ -1160,15 +1159,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-shell": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
-      "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@tanstack/react-query": "^5.99.2",
     "@tauri-apps/api": "^2.11.0",
-    "@tauri-apps/plugin-shell": "^2.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zustand": "^5.0.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -896,15 +896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,8 +2058,6 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
- "tauri-plugin-fs",
- "tauri-plugin-shell",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2484,7 +2473,6 @@ version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
- "dunce",
  "is-wsl",
  "libc",
  "pathdiff",
@@ -2538,16 +2526,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "pango"
@@ -3561,42 +3539,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4030,27 +3976,6 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
-]
-
-[[package]]
-name = "tauri-plugin-shell"
-version = "2.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
-dependencies = [
- "encoding_rs",
- "log",
- "open",
- "os_pipe",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "shared_child",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,3 +74,21 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [[bin]]
 name = "maplelink"
 path = "src/main.rs"
+
+# The shipped binary is downloaded on every update, so it's worth optimising for
+# size. This is a launcher: it spends its time waiting on the network and on the
+# user, so trading throughput for a smaller download costs nothing anyone can
+# feel. Together these take the exe from 23.4 MB to 12.6 MB.
+[profile.release]
+# Size over speed. "z" also drops loop vectorisation, which nothing here needs.
+opt-level = "z"
+# Whole-program optimisation across crate boundaries — the largest single win,
+# since it lets unused paths through the dependency tree fall away.
+lto = "fat"
+# One unit per crate: slower to build, but no duplicated inlining between units.
+codegen-units = 1
+# Symbol names serve no purpose in a shipped build; panics keep file and line.
+strip = true
+# Deliberately NOT panic = "abort": it would save a little more, but the code
+# leans on `expect()` in places (the WebView2 COM calls among them), and today a
+# panic there takes down one spawned task. Aborting would take down the app.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,8 +28,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
 rolling-file = "0.2"
 tauri-plugin-dialog = "2"
-tauri-plugin-fs = "2"
-tauri-plugin-shell = "2"
 base64 = "0.22.1"
 open = "5.3.4"
 urlencoding = "2.1.3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,13 @@
 {
   "identifier": "default",
   "description": "Default capabilities for MapleLink",
-  "windows": ["main", "debug-console", "gamepass-login", "recaptcha_window", "web-login"],
+  "windows": [
+    "main",
+    "debug-console",
+    "gamepass-login",
+    "recaptcha_window",
+    "web-login"
+  ],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
@@ -13,13 +19,6 @@
     "core:window:allow-current-monitor",
     "core:window:allow-scale-factor",
     "dialog:default",
-    "dialog:allow-open",
-    "fs:default",
-    "fs:allow-read",
-    "fs:allow-write",
-    "fs:allow-exists",
-    "fs:allow-mkdir",
-    "shell:default",
-    "shell:allow-open"
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -256,8 +256,6 @@ pub fn run() {
     tauri::Builder::default()
         // -- Plugins --------------------------------------------------------
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_shell::init())
         // -- Command handlers -----------------------------------------------
         .invoke_handler(tauri::generate_handler![
             commands::auth::create_session,

--- a/src-tauri/src/services/web_popup_service.rs
+++ b/src-tauri/src/services/web_popup_service.rs
@@ -15,28 +15,22 @@ use crate::models::session::Region;
 use crate::services::cookie_native;
 use crate::services::webview_util::WEBVIEW_USER_AGENT;
 
-/// Stop `tauri-plugin-shell` from hijacking `<a target="_blank">` in these
-/// remote pages.
+/// Keep `<a target="_blank">` navigations inside the popup that owns them.
 ///
-/// The plugin injects a body click listener into every webview that cancels the
-/// click and routes the link through `plugin:shell|open`. On beanfun that fails
-/// twice over: the site's CSP has no `ipc.localhost` in `connect-src`, and these
-/// popup windows hold no capability for the command — so the click is swallowed
-/// and buttons on the member centre simply do nothing. It is also the wrong
-/// destination: the app runs elevated, so opening the browser that way is what
-/// corrupts the user's Chrome profile (see the unelevated `shell_open` path).
+/// Left to itself WebView2 answers such a click by opening a bare window of its
+/// own. Three of these popups intercept that natively (`NewWindowRequested`),
+/// but retargeting the link is both simpler and covers the ones that don't.
 ///
-/// A capture-phase listener runs before the plugin's, and only rewrites the
-/// target — no `preventDefault`, no `stopPropagation`, so the page's own
-/// handlers still see the click. The plugin then ignores the link (it only acts
-/// on `_blank`) and normal navigation happens inside the popup, which is what
-/// its native `NewWindowRequested` handler does with these links anyway.
+/// This began as a workaround for `tauri-plugin-shell`, which injected a body
+/// click listener into every webview and routed these links through
+/// `plugin:shell|open` — swallowed on beanfun, whose CSP blocks the IPC. That
+/// plugin is no longer shipped, so only the retarget remains.
 ///
 /// Two details matter. The resolved `a.href` is what gets tested, not the raw
-/// attribute — the plugin resolves it too, so reading the attribute let every
-/// relative link slip through to it. And the target becomes `_top` rather than
-/// `_self`: a link inside a frame would otherwise navigate that frame, and sites
-/// like `accounts.gamania.com` refuse to be framed (`frame-ancestors 'none'`).
+/// attribute, so relative links are caught too. And the target becomes `_top`
+/// rather than `_self`: a link inside a frame would otherwise navigate that
+/// frame, and sites like `accounts.gamania.com` refuse to be framed
+/// (`frame-ancestors 'none'`).
 const KEEP_LINKS_IN_WINDOW: &str = r#"
 (function () {
   document.addEventListener('click', function (e) {


### PR DESCRIPTION
## Why

`MapleLink.exe` was 23.2 MB, and auto-update downloads it in full every time — often over the very connections that led people to run an accelerator in the first place.

## Result

**23.17 MB → 11.68 MB (−50%)**, installer **4.94 MB → 3.17 MB (−36%)**. Every figure below is a real `tauri build`, not a raw `cargo build`.

| Step | exe | |
|---|---|---|
| 0.4.6 as shipped | 23.17 MB | no `[profile.release]` at all |
| `lto = "fat"`, `codegen-units = 1`, `strip` | 20.05 MB | −13% |
| `opt-level = "s"` | 15.10 MB | −35% |
| `opt-level = "z"` | 12.89 MB | −44% |
| drop `tauri-plugin-fs` + `tauri-plugin-shell` | **11.68 MB** | **−50%** |

## The release profile

There was none, so it shipped on cargo defaults: no LTO, sixteen codegen units, symbols left in. Nothing here changes behaviour — same code, compiled for size. `opt-level = "z"` also drops loop vectorisation, which nothing here needs: this is a launcher, and it spends its time waiting on the network and on the user.

Build time roughly doubles. CI absorbs that once per release.

## Two plugins nothing used

`tauri-plugin-fs` and `tauri-plugin-shell` were registered at startup and never called — no Rust caller, no frontend import; the only mention of the shell plugin anywhere is a comment naming it as the thing *not* to use. Between them: 1.2 MB, and seven capability permissions including filesystem read and write, granted to a plugin no code reaches.

Dropping the shell plugin also removes the click listener it injected into every webview — the thing that swallowed the member-centre buttons behind beanfun's CSP (fixed by hand in #62). The retarget from that fix stays, since it still covers popups without a native `NewWindowRequested` handler, with its comment corrected to describe what it does now rather than what it used to fight.

## Measured and rejected

- **`panic = "abort"`** — the usual next step, left out on purpose. The code leans on `expect()` in places (the WebView2 COM calls among them) where a panic today takes down one spawned task; aborting would take down the app. Not worth a few hundred KB.
- **Narrowing `tokio` to the features actually used** — 9 KB. LTO already drops the rest, so it was reverted rather than carried as churn.
- **npm side** — the runtime dependency list is already six packages, and the bundle is 935 KB of a 11.68 MB binary. Nothing there to win.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (110 passed), `tsc`, `eslint`, `prettier --check`, `npm audit` (clean), and a full `tauri build` — all green.

## Worth a reviewer's attention

Size is measurable from here; **behaviour under `opt-level = "z"` is not**. Already smoke-tested by the author on the built exe. Worth one more pass before release, particularly anything touching the two removed plugins: the file picker (dialog plugin, still present) and links inside the member centre.