### PR TITLE
ci(tw): wait for the file, not for the installer

### DIFF
--- a/.github/workflows/ggm-watch.yml
+++ b/.github/workflows/ggm-watch.yml
@@ -92,6 +92,9 @@ jobs:
     needs: check
     if: needs.check.outputs.changed == 'true'
     runs-on: windows-latest
+    # A silent install that isn't silent waits for a click that will never come.
+    # Nothing here is worth more than a few minutes of a runner.
+    timeout-minutes: 12
     outputs:
       cv: ${{ steps.read.outputs.cv }}
       hash: ${{ steps.read.outputs.hash }}
@@ -110,18 +113,57 @@ jobs:
           "downloaded {0:N1} MB" -f ((Get-Item setup.exe).Length / 1MB)
 
           $dir = Join-Path $env:RUNNER_TEMP 'ggm'
+          $log = Join-Path $env:RUNNER_TEMP 'install.log'
           $switches = @(
-            '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/NOICONS', '/SP-', "/DIR=$dir"
+            '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/NOICONS', '/SP-',
+            "/DIR=$dir", "/LOG=$log"
           )
-          $p = Start-Process -FilePath .\setup.exe -Wait -PassThru -ArgumentList $switches
-          "installer exit code: $($p.ExitCode)"
+
+          # Not `-Wait`. This installer finishes in about thirty seconds and then
+          # puts up "installation succeeded" and waits for someone to click OK —
+          # which, on a runner with no desktop, is forever. So wait for the file
+          # instead of for the process: the file is the only thing wanted here,
+          # and it exists well before the box appears.
+          $p = Start-Process -FilePath .\setup.exe -PassThru -ArgumentList $switches
+          $deadline = (Get-Date).AddMinutes(4)
+          $dll = $null
+          while ((Get-Date) -lt $deadline) {
+            $dll = Get-ChildItem $dir -Recurse -Filter GGMWebStart.dll -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+            # Written, and no longer being written to.
+            if ($dll -and $dll.Length -gt 0) {
+              Start-Sleep -Seconds 2
+              break
+            }
+            if ($p.HasExited) { break }
+            Start-Sleep -Seconds 2
+          }
+
+          if ($p.HasExited) {
+            "installer exit code: $($p.ExitCode)"
+          } else {
+            "installer still running (it waits on a message box); stopping it"
+            Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+          }
 
           # It may start itself when it finishes; nothing here wants it running.
           Get-Process -Name GGMWebStart, GamaniaGameDownloader -ErrorAction SilentlyContinue |
             Stop-Process -Force -ErrorAction SilentlyContinue
 
-          $dll = Get-ChildItem $dir -Recurse -Filter GGMWebStart.dll -ErrorAction SilentlyContinue |
-            Select-Object -First 1
+          # Its own log says what it was doing, which is the one thing the last
+          # attempt could not tell us.
+          if (Test-Path $log) {
+            "--- installer log (last 40 lines) ---"
+            Get-Content $log -Tail 40
+          } else {
+            "no installer log at $log"
+          }
+
+          # Re-read, in case the wait above ended before it appeared.
+          if (-not $dll) {
+            $dll = Get-ChildItem $dir -Recurse -Filter GGMWebStart.dll -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+          }
           if (-not $dll) {
             Write-Host "::error::GGMWebStart.dll not found under $dir"
             Get-ChildItem $dir -Recurse -File -ErrorAction SilentlyContinue |


### PR DESCRIPTION
The forced run hung: the installer downloaded, the silent install started, and `Start-Process -Wait` sat there until it was cancelled six minutes later, with nothing to say why.

Bounding it and passing `/LOG` produced the answer on the next attempt:

```
14:34:14  Installation process succeeded.
14:34:14  Message box (OK):
          已成功安裝 gamania Games Manager 1.5.0.2 在您的電腦中。
```

It finishes in about thirty seconds, then waits for someone to click OK — which on a runner with no desktop never comes. `/SUPPRESSMSGBOXES` doesn't cover it; that box is the installer's own, not Setup's.

## What it does now

Waits for the **file** rather than the process. `GGMWebStart.dll` is written well before the box appears and is the only thing this job wants, so once it is there the installer is stopped and the values read. Four minutes is the ceiling rather than the cost, and the job has a twelve-minute limit so it can never hang again.

## Verified

Two runs on this branch, dispatched without merging:

```
Read the new pair: success  (14:47:41 → 14:48:09)     28 seconds
  downloaded 16.4 MB
  installer still running (it waits on a message box); stopping it
  read    D:\a\_temp\ggm\GGMWebStart.dll
  version 1.5.0.2
  sha256  dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06
```

The same pair a Windows machine with the manager installed reports. Three jobs, 44 seconds total.

This closes the last unverified assumption in the watcher: CI can now produce both halves of the pair on its own, so publishing a hotfix no longer needs anyone to have a Windows machine with the manager on it.