### PR TITLE
ci(tw): make the proposal come from the default branch, and survive refusal

### DIFF
--- a/.github/workflows/ggm-watch.yml
+++ b/.github/workflows/ggm-watch.yml
@@ -210,7 +210,13 @@ jobs:
       issues: write
 
     steps:
+      # The default branch, not the ref this run was triggered from. A schedule
+      # gives the same thing either way, but a dispatch from a feature branch
+      # would otherwise cut the proposal from that branch and carry its
+      # unrelated commits into the pull request.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       # With both halves in hand there is nothing left to decide, so open the
       # change rather than a request for someone to make it. An issue would be
@@ -251,12 +257,38 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git add ggm-client.json
+          # The default branch may already carry these values — the version
+          # that looked stale can have come from the ref this run was
+          # dispatched from, or a previous proposal may have landed since.
+          # Either way there is nothing to propose, and that is not a failure.
+          if git diff --cached --quiet; then
+            echo "the default branch already publishes $VERSION; nothing to propose"
+            exit 0
+          fi
           git commit -m "chore(tw): publish client-integrity values for GGM $VERSION"
           git push origin "$branch"
 
-          gh pr create \
+          body=$(printf 'beanfun now ships Gamania Games Manager `%s`. These values were read from\n`GGMWebStart.dll` inside its installer, on a runner that installed it.\n%s\nMerging publishes them: the app fetches this file and caches it for six hours,\nso every user is carried across without a release and without doing anything.\n\nUntil then, TW launches keep working for anyone whose installed manager is\nnewer than the pair we publish, and for anyone whose current values still\npass.\n\nInstaller: %s\n\nOpened by `.github/workflows/ggm-watch.yml`.\n' "$VERSION" "$note" "$URL")
+
+          # Opening the request can be refused outright: "Allow GitHub Actions
+          # to create and approve pull requests" is a repository setting, and
+          # it is off by default. The branch is already pushed by then, so the
+          # work is not lost — say where it is rather than failing and leaving
+          # a branch nobody was told about.
+          if gh pr create \
             --title "chore(tw): publish client-integrity values for GGM $VERSION" \
-            --body "$(printf 'beanfun now ships Gamania Games Manager `%s`. These values were read from\n`GGMWebStart.dll` inside its installer, on a runner that installed it.\n%s\nMerging publishes them: the app fetches this file and caches it for six hours,\nso every user is carried across without a release and without doing anything.\n\nUntil then, TW launches keep working for anyone whose installed manager is\nnewer than the pair we publish, and for anyone whose current values still\npass.\n\nInstaller: %s\n\nOpened by `.github/workflows/ggm-watch.yml`.\n' "$VERSION" "$note" "$URL")"
+            --body "$body"; then
+            exit 0
+          fi
+
+          echo "::warning::could not open a pull request; falling back to an issue"
+          gh label create ggm-version \
+            --description "beanfun shipped a new Gamania Games Manager" \
+            --color FBCA04 2>/dev/null || true
+          gh issue create \
+            --title "Gamania Games Manager updated to $VERSION" \
+            --label ggm-version \
+            --body "$(printf '%s\n\n---\n\nThe branch `%s` is pushed and holds this change, but the pull request could\nnot be opened — most likely "Allow GitHub Actions to create and approve pull\nrequests" is off under Settings → Actions → General.\n\nOpen it here: %s/compare/%s?expand=1\n' "$body" "$branch" "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" "$branch")"
 
       # Only when the values could not be read. There is nothing to merge, so
       # the version alone is the message.


### PR DESCRIPTION
The propose path had never run. A forced dispatch finds the version unchanged and skips it, so the branch, commit and pull request it creates were unproven.

Running it for real — by lowering the published `cv` on a throwaway branch — found three things, none of them the one I expected.

## 1. The pull request can be refused

```
jq edit ✓  branch ✓  commit ✓  push ✓
gh pr create ✗  GitHub Actions is not permitted to create or approve pull requests
```

"Allow GitHub Actions to create and approve pull requests" is a repository setting, off by default. The job failed *after* pushing a branch nobody had been told about — the work done, and no sign of it anywhere anyone looks.

A refusal now falls back to an issue carrying the same body, the branch name, a compare link, and which setting to turn on.

## 2. The proposal was cut from the triggering ref

The test's pull request contained the **workflow file**, not `ggm-client.json` — `actions/checkout` had taken the branch the run was dispatched from, and carried its unrelated commits into what should be a two-value change.

A scheduled run gives the same thing either way, so this would have sat unnoticed until someone dispatched from a feature branch. The propose job now checks out the default branch explicitly.

## 3. No difference was treated as failure

With #2 fixed, the job read the default branch, found the values already correct, and failed on `nothing to commit`. That happens whenever the version that looked stale came from the dispatching ref, or a previous proposal has since landed. It says so and exits cleanly.

## Final run

```
Check the announced version: success
Read the new pair:           success
Propose the new pair:        success
  → the default branch already publishes 1.5.0.2; nothing to propose
```

The test branch, the `ggm/1.5.0.2` branch and the pull request it opened are all deleted.

## Still unproven

A run where the values genuinely differ, end to end. That needs the default branch to actually carry a stale `cv`, so it waits for a real update. Every individual step — the `jq` edit (checked locally against both repos' file shapes), branch, commit, push, `gh pr create` — has been observed working at least once, just not all in one run.