### PR TITLE
ci(tw): close the blockquote before the sentence after it

### DIFF
--- a/.github/workflows/ggm-watch.yml
+++ b/.github/workflows/ggm-watch.yml
@@ -250,7 +250,9 @@ jobs:
 
           note=""
           if [ -n "$CV" ] && [ "$CV" != "$VERSION" ]; then
-            note=$(printf '\n> beanfun announces `%s` but the installed file reports `%s`. The file'"'"'s\n> version is used here; check which one the endpoint accepts before merging.\n' "$VERSION" "$CV")
+            # No trailing newline: command substitution strips those anyway, so
+            # the blank line that ends the quote is added where it is used.
+            note=$(printf '\n> beanfun announces `%s` but the installed file reports `%s`. The file'"'"'s\n> version is used here; check which one the endpoint accepts before merging.' "$VERSION" "$CV")
           fi
 
           git config user.name "github-actions[bot]"
@@ -268,7 +270,7 @@ jobs:
           git commit -m "chore(tw): publish client-integrity values for GGM $VERSION"
           git push origin "$branch"
 
-          body=$(printf 'beanfun now ships Gamania Games Manager `%s`. These values were read from\n`GGMWebStart.dll` inside its installer, on a runner that installed it.\n%s\nMerging publishes them: the app fetches this file and caches it for six hours,\nso every user is carried across without a release and without doing anything.\n\nUntil then, TW launches keep working for anyone whose installed manager is\nnewer than the pair we publish, and for anyone whose current values still\npass.\n\nInstaller: %s\n\nOpened by `.github/workflows/ggm-watch.yml`.\n' "$VERSION" "$note" "$URL")
+          body=$(printf 'beanfun now ships Gamania Games Manager `%s`. These values were read from\n`GGMWebStart.dll` inside its installer, on a runner that installed it.\n%s\n\nMerging publishes them: the app fetches this file and caches it for six hours,\nso every user is carried across without a release and without doing anything.\n\nUntil then, TW launches keep working for anyone whose installed manager is\nnewer than the pair we publish, and for anyone whose current values still\npass.\n\nInstaller: %s\n\nOpened by `.github/workflows/ggm-watch.yml`.\n' "$VERSION" "$note" "$URL")
 
           # Opening the request can be refused outright: "Allow GitHub Actions
           # to create and approve pull requests" is a repository setting, and


### PR DESCRIPTION
The proposal warns, in a blockquote, when beanfun's announced version and the version reported by the file disagree. `$(...)` strips trailing newlines, so nothing separated the quote from the sentence after it, and markdown's lazy continuation swallowed that sentence into the quote:

```
> beanfun announces 1.5.0.3 but the installed file reports 1.5.0.2. The file's
> version is used here; check which one the endpoint accepts before merging.
Merging publishes them: the app fetches this file and caches it for six hours,
```

The paragraph saying what merging does was rendered as part of the warning about not merging yet — visible only on a run where the two versions disagree, which has never happened.

Found by rendering the body locally with `git` and `gh` stubbed out. That is worth keeping in mind as the way to read this text before it is posted: the reporting step is the one part of the watcher whose output is prose, and prose nobody reads until it matters.