### PR TITLE
feat(ui): user-selectable accent colour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "maplelink",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplelink",
-      "version": "0.4.7",
+      "version": "0.5.0",
       "dependencies": {
+        "@fontsource-variable/noto-sans-tc": "^5.3.0",
         "@tanstack/react-query": "^5.99.2",
         "@tauri-apps/api": "^2.11.0",
         "react": "^19.0.0",
@@ -435,6 +436,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-sans-tc": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-tc/-/noto-sans-tc-5.3.0.tgz",
+      "integrity": "sha512-sniyvTx+yRXlce9bjBV0i3kBG3/YFJiz6SZA9plNJLCR4TbY8il+G759gAXWHZu01eAclbJEN2YR+qbQjZTjkg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\""
   },
   "dependencies": {
+    "@fontsource-variable/noto-sans-tc": "^5.3.0",
     "@tanstack/react-query": "^5.99.2",
     "@tauri-apps/api": "^2.11.0",
     "react": "^19.0.0",

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -242,6 +242,20 @@ fn apply_config_field(config: &mut AppConfig, key: &str, value: &str) -> Result<
         "compactUi" | "compact_ui" => {
             config.compact_ui = parse_bool(value)?;
         }
+        "accentColor" | "accent_color" => {
+            // Empty clears it; otherwise it must be #rrggbb.
+            let v = value.trim();
+            let ok = v.is_empty()
+                || (v.len() == 7
+                    && v.starts_with('#')
+                    && v[1..].chars().all(|c| c.is_ascii_hexdigit()));
+            if !ok {
+                return Err(ConfigError::ParseError {
+                    reason: format!("accent_color must be #rrggbb, got: {value}"),
+                });
+            }
+            config.accent_color = v.to_lowercase();
+        }
         "__reset__" => {
             *config = AppConfig::default();
         }

--- a/src-tauri/src/core/config_parser.rs
+++ b/src-tauri/src/core/config_parser.rs
@@ -142,6 +142,9 @@ pub fn parse_ini(input: &str) -> Result<AppConfig, ConfigError> {
         if let Some(v) = general.get("compact_ui") {
             config.compact_ui = parse_bool(v, "compact_ui", defaults.compact_ui);
         }
+        if let Some(v) = general.get("accent_color") {
+            config.accent_color = v.clone();
+        }
     }
 
     // --- [game] ---
@@ -263,6 +266,7 @@ pub fn serialize_ini(config: &AppConfig) -> String {
     ));
     out.push_str(&format!("github_hosts = {}\n", config.github_hosts));
     out.push_str(&format!("compact_ui = {}\n", config.compact_ui));
+    out.push_str(&format!("accent_color = {}\n", config.accent_color));
     out.push('\n');
 
     // [game]
@@ -614,6 +618,7 @@ x = not_a_number
             default_login_view: DefaultLoginView::Qr,
             github_hosts: false,
             compact_ui: true,
+            accent_color: "#3b82f6".into(),
         };
         let ini = serialize_ini(&original);
         let parsed = parse_ini(&ini).unwrap();

--- a/src-tauri/src/core/game_launcher.rs
+++ b/src-tauri/src/core/game_launcher.rs
@@ -272,6 +272,7 @@ mod tests {
                         default_login_view: crate::models::config::DefaultLoginView::Normal,
                         github_hosts: true,
                         compact_ui: false,
+                        accent_color: String::new(),
                     }
                 },
             )

--- a/src-tauri/src/models/config.rs
+++ b/src-tauri/src/models/config.rs
@@ -111,6 +111,9 @@ pub struct AppConfig {
     /// covering it. Every other page keeps its size. Default: off.
     #[serde(default)]
     pub compact_ui: bool,
+    /// UI accent colour as `#rrggbb`. Empty = the built-in maple orange.
+    #[serde(default)]
+    pub accent_color: String,
 }
 
 fn default_true() -> bool {
@@ -159,6 +162,7 @@ impl Default for AppConfig {
             default_login_view: DefaultLoginView::Normal,
             github_hosts: true,
             compact_ui: false,
+            accent_color: String::new(),
         }
     }
 }

--- a/src-tauri/src/services/beanfun_service.rs
+++ b/src-tauri/src/services/beanfun_service.rs
@@ -3110,8 +3110,8 @@ mod tests {
         let cipher = des::Des::new_from_slice(key.as_bytes()).unwrap();
         let mut padded = plaintext.as_bytes().to_vec();
         padded.resize(padded.len().div_ceil(8) * 8, 0);
-        for chunk in padded.chunks_exact_mut(8) {
-            let block: &mut des::cipher::Array<u8, _> = chunk.try_into().unwrap();
+        for chunk in padded.as_chunks_mut::<8>().0 {
+            let block: &mut des::cipher::Array<u8, _> = chunk.as_mut_slice().try_into().unwrap();
             cipher.encrypt_block(block);
         }
         let cipher_hex: String = padded.iter().map(|b| format!("{b:02x}")).collect();

--- a/src-tauri/src/utils/crypto.rs
+++ b/src-tauri/src/utils/crypto.rs
@@ -28,8 +28,8 @@ pub fn des_ecb_decrypt_hex(hex_ciphertext: &str, key_ascii: &str) -> Option<Stri
     }
 
     let mut plaintext = ciphertext;
-    for chunk in plaintext.chunks_exact_mut(8) {
-        let block: &mut des::cipher::Array<u8, _> = chunk.try_into().unwrap();
+    for chunk in plaintext.as_chunks_mut::<8>().0 {
+        let block: &mut des::cipher::Array<u8, _> = chunk.as_mut_slice().try_into().unwrap();
         cipher.decrypt_block(block);
     }
 

--- a/src-tauri/tests/config_roundtrip.rs
+++ b/src-tauri/tests/config_roundtrip.rs
@@ -123,6 +123,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 default_login_view: DefaultLoginView::Qr,
                 github_hosts: false,
                 compact_ui: true,
+                accent_color: "#3b82f6".into(),
             }
         },
     )

--- a/src-tauri/tests/no_credentials_on_disk.rs
+++ b/src-tauri/tests/no_credentials_on_disk.rs
@@ -128,6 +128,7 @@ fn arb_app_config() -> impl Strategy<Value = AppConfig> {
                 default_login_view: maplelink_lib::models::config::DefaultLoginView::Normal,
                 github_hosts: true,
                 compact_ui: false,
+                accent_color: String::new(),
             }
         },
     )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { useErrorToastStore } from "./lib/stores/error-toast-store";
 import { ANNOUNCEMENT_ID } from "./lib/announcement";
 import { useConfigStore } from "./lib/stores/config-store";
 import { ONBOARDING_ID } from "./lib/onboarding";
+import { applyAccent } from "./lib/accent";
 import { LoginPage } from "./features/login/LoginPage";
 import { MainPage } from "./features/launcher/MainPage";
 import { ToolboxPage } from "./features/toolbox/ToolboxPage";
@@ -74,6 +75,7 @@ function useInitialConfigSync() {
     if (!config) return;
     setTheme(config.theme);
     setLanguage(config.language);
+    applyAccent(config.accentColor ?? "");
   }, [config, setTheme, setLanguage]);
 
   return isLoading;
@@ -335,7 +337,7 @@ export function App() {
         <AnnouncementBanner onOpen={openAnnouncement} onClose={hideAnnouncementBanner} />
       )}
       {showBanner && (
-        <div className="flex shrink-0 items-center justify-between bg-[rgba(232,162,58,0.12)] px-3 py-1.5 backdrop-blur-sm">
+        <div className="flex shrink-0 items-center justify-between bg-[rgba(var(--accent-rgb),0.12)] px-3 py-1.5 backdrop-blur-sm">
           <button
             onClick={() => setPendingUpdate(availableUpdate)}
             className="flex-1 text-left text-[11px] text-accent transition-opacity hover:opacity-80"
@@ -403,7 +405,7 @@ export function App() {
             )}
             {classicStatus === "launched" && <span className="text-[22px]">✓</span>}
             {classicStatus === "needs_login" && (
-              <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[rgba(232,162,58,0.14)] text-[17px]">
+              <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[rgba(var(--accent-rgb),0.14)] text-[17px]">
                 🔑
               </span>
             )}
@@ -502,7 +504,7 @@ export function App() {
                   commands.openExternal("https://maplestory.beanfun.com/download").catch(() => {});
                   setPatcherInfo(null);
                 }}
-                className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+                className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
               >
                 {t("launcher.patcher_download")}
               </button>

--- a/src/features/launcher/AccountContextMenu.tsx
+++ b/src/features/launcher/AccountContextMenu.tsx
@@ -36,7 +36,7 @@ function MenuItem({
   return (
     <button
       onClick={onClick}
-      className={`flex w-full items-center gap-2 text-left text-[var(--text)] transition-colors hover:bg-[rgba(232,162,58,0.08)] hover:text-accent ${
+      className={`flex w-full items-center gap-2 text-left text-[var(--text)] transition-colors hover:bg-[rgba(var(--accent-rgb),0.08)] hover:text-accent ${
         compact ? "px-3 py-[5px] text-[11.5px]" : "gap-2.5 px-4 py-2 text-[12px]"
       }`}
     >
@@ -93,7 +93,7 @@ function AccountDetailView({
     <div className="flex flex-col gap-4">
       {/* Hero */}
       <div className="flex items-center gap-3.5">
-        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-accent to-[#c47a1a] text-lg font-bold text-white shadow-[0_4px_16px_rgba(232,162,58,0.35)]">
+        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-accent to-[var(--accent-dark)] text-lg font-bold text-[var(--on-accent)] shadow-[0_4px_16px_rgba(var(--accent-rgb),0.35)]">
           {(account.displayName || "?").charAt(0)}
         </div>
         <div className="min-w-0 flex-1">
@@ -136,7 +136,7 @@ function AccountDetailView({
       {/* Days counter */}
       {days !== null && (
         <div className="relative flex flex-col items-center gap-0.5 py-2">
-          <div className="pointer-events-none absolute h-[100px] w-[100px] rounded-full bg-[radial-gradient(circle,rgba(232,162,58,0.35),transparent_70%)] opacity-30" />
+          <div className="pointer-events-none absolute h-[100px] w-[100px] rounded-full bg-[radial-gradient(circle,rgba(var(--accent-rgb),0.35),transparent_70%)] opacity-30" />
           <div className="relative text-[52px] leading-none font-black text-accent">{days}</div>
           <div className="text-[12px] font-semibold tracking-[2px] text-[var(--text-dim)] uppercase">
             {t("launcher.context.detail_days")}
@@ -207,7 +207,7 @@ function EditAccountView({
         </button>
         <button
           onClick={() => name && onSave(name, syncToServer)}
-          className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+          className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
         >
           {t("common.ok")}
         </button>
@@ -244,7 +244,7 @@ function EmailResultView({ email, t }: { email: string | null; t: (key: string) 
       </div>
       <button
         onClick={handleCopy}
-        className="self-center rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+        className="self-center rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
       >
         {copied ? t("common.copied") : t("common.copy")}
       </button>

--- a/src/features/launcher/AccountGrid.tsx
+++ b/src/features/launcher/AccountGrid.tsx
@@ -294,7 +294,7 @@ function CardItem({
         isDragging ? "opacity-50" : ""
       } ${isBumped ? "animate-[dragBump_0.2s_ease]" : ""} ${
         isSelected
-          ? "border-accent bg-[rgba(232,162,58,0.05)] shadow-[0_0_20px_rgba(232,162,58,0.15)]"
+          ? "border-accent bg-[rgba(var(--accent-rgb),0.05)] shadow-[0_0_20px_rgba(var(--accent-rgb),0.15)]"
           : "border-border bg-[var(--surface)] hover:border-[var(--border)] hover:bg-[var(--surface-hover)]"
       }`}
     >
@@ -375,8 +375,8 @@ function ListItem({
       } ${isDragging ? "opacity-50" : ""} ${isBumped ? "animate-[dragBump_0.2s_ease]" : ""} ${
         isSelected
           ? compact
-            ? "border-[rgba(232,162,58,0.55)] bg-[rgba(232,162,58,0.08)]"
-            : "border-accent bg-[rgba(232,162,58,0.05)]"
+            ? "border-[rgba(var(--accent-rgb),0.55)] bg-[rgba(var(--accent-rgb),0.08)]"
+            : "border-accent bg-[rgba(var(--accent-rgb),0.05)]"
           : compact
             ? "border-transparent hover:bg-[var(--surface-hover)]"
             : "border-border bg-[var(--surface)] hover:bg-[var(--surface-hover)]"

--- a/src/features/launcher/CompactMain.tsx
+++ b/src/features/launcher/CompactMain.tsx
@@ -111,7 +111,7 @@ export function CompactMain(p: CompactMainProps) {
               ? ` · ${t("launcher.running")}${p.gamePid !== null ? ` (PID ${p.gamePid})` : ""}`
               : ""
           }`}
-          className="relative flex h-[22px] shrink-0 items-center justify-center gap-1 rounded-[6px] bg-gradient-to-br from-[#c46a00] to-accent px-2.5 text-[10.5px] font-extrabold tracking-[0.5px] text-white shadow-[0_2px_8px_var(--accent-glow)] transition-all hover:translate-y-[-1px] hover:shadow-[0_3px_12px_var(--accent-glow)] active:scale-[0.96] disabled:transform-none disabled:opacity-40"
+          className="relative flex h-[22px] shrink-0 items-center justify-center gap-1 rounded-[6px] bg-gradient-to-br from-[var(--accent-deep)] to-accent px-2.5 text-[10.5px] font-extrabold tracking-[0.5px] text-[var(--on-accent)] shadow-[0_2px_8px_var(--accent-glow)] transition-all hover:translate-y-[-1px] hover:shadow-[0_3px_12px_var(--accent-glow)] active:scale-[0.96] disabled:transform-none disabled:opacity-40"
         >
           <span className="pointer-events-none absolute inset-0 rounded-[6px] bg-gradient-to-b from-white/15 to-transparent" />
           <span className="relative text-[10px]">{p.showClassic ? "🍁" : "▶"}</span>
@@ -162,7 +162,7 @@ export function CompactMain(p: CompactMainProps) {
                   onClick={() => p.onClassicGame(classic)}
                   className={`flex h-[18px] items-center justify-center gap-1 rounded-[4px] text-[10.5px] font-bold transition-all ${
                     active
-                      ? "bg-gradient-to-br from-[#c46a00] to-accent text-white shadow-[0_1px_6px_var(--accent-glow)]"
+                      ? "bg-gradient-to-br from-[var(--accent-deep)] to-accent text-[var(--on-accent)] shadow-[0_1px_6px_var(--accent-glow)]"
                       : "text-text-dim hover:text-[var(--text)]"
                   }`}
                 >
@@ -218,7 +218,7 @@ export function CompactMain(p: CompactMainProps) {
             otp.copied
               ? "bg-[rgba(74,222,128,0.08)] text-green-400"
               : otp.credentials
-                ? "bg-[rgba(232,162,58,0.08)] text-accent hover:bg-[rgba(232,162,58,0.13)]"
+                ? "bg-[rgba(var(--accent-rgb),0.08)] text-accent hover:bg-[rgba(var(--accent-rgb),0.13)]"
                 : "cursor-default bg-[var(--surface)] text-text-faint"
           }`}
         >
@@ -269,7 +269,7 @@ export function CompactMain(p: CompactMainProps) {
               aria-checked={otp.autoInput}
               onClick={() => otp.setAutoInput(!otp.autoInput)}
               className={`relative h-[18px] w-[32px] shrink-0 rounded-full transition-colors ${
-                otp.autoInput ? "bg-[rgba(232,162,58,0.35)]" : "bg-[var(--surface-hover)]"
+                otp.autoInput ? "bg-[rgba(var(--accent-rgb),0.35)]" : "bg-[var(--surface-hover)]"
               }`}
             >
               <span
@@ -285,7 +285,7 @@ export function CompactMain(p: CompactMainProps) {
             <button
               onClick={otp.getOtp}
               disabled={!p.selectedAccountId || otp.busy}
-              className="flex h-[18px] items-center gap-1 rounded-l-[5px] bg-[rgba(232,162,58,0.14)] px-1.5 text-[10.5px] leading-none font-semibold whitespace-nowrap text-accent transition-all hover:bg-[rgba(232,162,58,0.22)] active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-40"
+              className="flex h-[18px] items-center gap-1 rounded-l-[5px] bg-[rgba(var(--accent-rgb),0.14)] px-1.5 text-[10.5px] leading-none font-semibold whitespace-nowrap text-accent transition-all hover:bg-[rgba(var(--accent-rgb),0.22)] active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-40"
             >
               ↻ {t("launcher.get_otp")}
             </button>
@@ -293,7 +293,7 @@ export function CompactMain(p: CompactMainProps) {
               onClick={() => setOtpMenuOpen(!otpMenuOpen)}
               disabled={!p.selectedAccountId}
               aria-label="More"
-              className="flex h-[18px] w-4 items-center justify-center rounded-r-[5px] border-l border-[rgba(232,162,58,0.25)] bg-[rgba(232,162,58,0.14)] text-accent transition-all hover:bg-[rgba(232,162,58,0.22)] disabled:cursor-not-allowed disabled:opacity-40"
+              className="flex h-[18px] w-4 items-center justify-center rounded-r-[5px] border-l border-[rgba(var(--accent-rgb),0.25)] bg-[rgba(var(--accent-rgb),0.14)] text-accent transition-all hover:bg-[rgba(var(--accent-rgb),0.22)] disabled:cursor-not-allowed disabled:opacity-40"
             >
               <svg
                 width="8"

--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -352,7 +352,7 @@ export function MainPage() {
             </button>
             <button
               onClick={handleConfirmRelaunch}
-              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
             >
               {t("launcher.relaunch_confirm")}
             </button>
@@ -446,7 +446,7 @@ export function MainPage() {
                     onClick={() => setClassicGame(classic)}
                     className={`rounded-full px-4 py-1.5 text-[12px] font-bold tracking-[1px] transition-all ${
                       classicGame === classic
-                        ? "bg-gradient-to-br from-[#c46a00] to-accent text-white shadow-[0_2px_10px_var(--accent-glow)]"
+                        ? "bg-gradient-to-br from-[var(--accent-deep)] to-accent text-[var(--on-accent)] shadow-[0_2px_10px_var(--accent-glow)]"
                         : "text-text-dim hover:text-[var(--text)]"
                     }`}
                   >
@@ -505,7 +505,7 @@ export function MainPage() {
             <button
               onClick={handlePlayClick}
               disabled={launching}
-              className="relative mt-1 flex h-[72px] w-[72px] items-center justify-center rounded-full border-none bg-gradient-to-br from-[#c46a00] to-accent text-[12px] font-extrabold tracking-[3px] text-white uppercase shadow-[0_4px_24px_var(--accent-glow),0_0_0_3px_rgba(232,162,58,0.1)] transition-all hover:scale-[1.08] hover:shadow-[0_6px_32px_rgba(232,162,58,0.5)] active:scale-[0.93] disabled:transform-none disabled:opacity-40"
+              className="relative mt-1 flex h-[72px] w-[72px] items-center justify-center rounded-full border-none bg-gradient-to-br from-[var(--accent-deep)] to-accent text-[12px] font-extrabold tracking-[3px] text-[var(--on-accent)] uppercase shadow-[0_4px_24px_var(--accent-glow),0_0_0_3px_rgba(var(--accent-rgb),0.1)] transition-all hover:scale-[1.08] hover:shadow-[0_6px_32px_rgba(var(--accent-rgb),0.5)] active:scale-[0.93] disabled:transform-none disabled:opacity-40"
             >
               {launching ? "..." : t("launcher.play")}
             </button>
@@ -543,7 +543,7 @@ export function MainPage() {
           {/* Top bar */}
           <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-3 py-2">
             <div className="flex items-center gap-1.5 text-[12px] text-text-dim">
-              <div className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-gradient-to-br from-accent to-[#c47a1a] text-[12px] font-bold text-white">
+              <div className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-gradient-to-br from-accent to-[var(--accent-dark)] text-[12px] font-bold text-[var(--on-accent)]">
                 {session?.accountName?.charAt(0)?.toUpperCase() ?? "?"}
               </div>
               <span className={`max-w-[200px] truncate ${nameMask}`}>
@@ -555,7 +555,7 @@ export function MainPage() {
               <span
                 ref={beansRef}
                 onClick={() => setBeansMenuOpen(!beansMenuOpen)}
-                className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-[rgba(232,162,58,0.15)] bg-[rgba(232,162,58,0.08)] px-2 py-0.5 text-[12px] whitespace-nowrap transition-all hover:bg-[rgba(232,162,58,0.14)]"
+                className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-[rgba(var(--accent-rgb),0.15)] bg-[rgba(var(--accent-rgb),0.08)] px-2 py-0.5 text-[12px] whitespace-nowrap transition-all hover:bg-[rgba(var(--accent-rgb),0.14)]"
               >
                 <span className="font-semibold text-accent">
                   {t("launcher.beans")}: <b>{remainPoint}</b>

--- a/src/features/launcher/OtpPanel.tsx
+++ b/src/features/launcher/OtpPanel.tsx
@@ -31,7 +31,7 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
             type="button"
             onClick={() => setAutoInput(!autoInput)}
             className={`relative h-[18px] w-8 shrink-0 rounded-[9px] transition-colors ${
-              autoInput ? "bg-[rgba(232,162,58,0.3)]" : "bg-[var(--surface-hover)]"
+              autoInput ? "bg-[rgba(var(--accent-rgb),0.3)]" : "bg-[var(--surface-hover)]"
             }`}
           >
             <span
@@ -53,8 +53,8 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
             copied
               ? "border-[rgba(74,222,128,0.4)] bg-[rgba(74,222,128,0.04)] text-green-400"
               : credentials
-                ? "border-[rgba(232,162,58,0.08)] bg-[rgba(232,162,58,0.04)] text-accent shadow-[0_0_20px_rgba(232,162,58,0.06)_inset,0_2px_8px_rgba(0,0,0,0.3)_inset] hover:border-[rgba(232,162,58,0.2)] hover:bg-[rgba(232,162,58,0.06)]"
-                : "cursor-default border-[rgba(232,162,58,0.08)] bg-[rgba(232,162,58,0.04)] text-text-faint"
+                ? "border-[rgba(var(--accent-rgb),0.08)] bg-[rgba(var(--accent-rgb),0.04)] text-accent shadow-[0_0_20px_rgba(var(--accent-rgb),0.06)_inset,0_2px_8px_rgba(0,0,0,0.3)_inset] hover:border-[rgba(var(--accent-rgb),0.2)] hover:bg-[rgba(var(--accent-rgb),0.06)]"
+                : "cursor-default border-[rgba(var(--accent-rgb),0.08)] bg-[rgba(var(--accent-rgb),0.04)] text-text-faint"
           }`}
         >
           {credentials?.otp ?? "••••••••••"}
@@ -101,7 +101,7 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
             onClick={getOtp}
             disabled={!selectedAccountId || busy}
             title={t("launcher.get_otp")}
-            className="flex h-10 w-10 items-center justify-center rounded-l-[10px] bg-gradient-to-br from-accent to-[#c47a1a] text-base text-white transition-all active:scale-[0.95] disabled:cursor-not-allowed disabled:opacity-40"
+            className="flex h-10 w-10 items-center justify-center rounded-l-[10px] bg-gradient-to-br from-accent to-[var(--accent-dark)] text-base text-[var(--on-accent)] transition-all active:scale-[0.95] disabled:cursor-not-allowed disabled:opacity-40"
           >
             ↻
           </button>
@@ -109,7 +109,7 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
             onClick={() => setMoreOpen(!moreOpen)}
             disabled={!selectedAccountId}
             aria-label="More"
-            className="flex h-10 w-5 items-center justify-center rounded-r-[10px] border-l border-white/25 bg-gradient-to-br from-accent to-[#c47a1a] text-white transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+            className="flex h-10 w-5 items-center justify-center rounded-r-[10px] border-l border-white/25 bg-gradient-to-br from-accent to-[var(--accent-dark)] text-[var(--on-accent)] transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
           >
             <svg
               width="9"

--- a/src/features/launcher/OtpPanel.tsx
+++ b/src/features/launcher/OtpPanel.tsx
@@ -95,33 +95,41 @@ export function OtpPanel({ selectedAccountId, onOtpFetched }: OtpPanelProps) {
           </span>
         </button>
 
-        {/* Split button: fetch, and a ▾ with copy one-time credentials */}
-        <div className="relative flex shrink-0 shadow-[0_2px_10px_var(--accent-glow)] transition-shadow hover:shadow-[0_4px_16px_var(--accent-glow)]">
-          <button
-            onClick={getOtp}
-            disabled={!selectedAccountId || busy}
-            title={t("launcher.get_otp")}
-            className="flex h-10 w-10 items-center justify-center rounded-l-[10px] bg-gradient-to-br from-accent to-[var(--accent-dark)] text-base text-[var(--on-accent)] transition-all active:scale-[0.95] disabled:cursor-not-allowed disabled:opacity-40"
+        {/* Split button: fetch, and a ▾ with copy one-time credentials. One
+            gradient across the pair (per-half gradients restart at the seam,
+            which saturated accents make very visible). */}
+        <div className="relative shrink-0">
+          <div
+            className={`flex overflow-hidden rounded-[10px] bg-gradient-to-br from-accent to-[var(--accent-dark)] shadow-[0_2px_10px_var(--accent-glow)] transition-all hover:shadow-[0_4px_16px_var(--accent-glow)] ${
+              !selectedAccountId ? "opacity-40" : ""
+            }`}
           >
-            ↻
-          </button>
-          <button
-            onClick={() => setMoreOpen(!moreOpen)}
-            disabled={!selectedAccountId}
-            aria-label="More"
-            className="flex h-10 w-5 items-center justify-center rounded-r-[10px] border-l border-white/25 bg-gradient-to-br from-accent to-[var(--accent-dark)] text-[var(--on-accent)] transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <svg
-              width="9"
-              height="9"
-              viewBox="0 0 10 10"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.6"
+            <button
+              onClick={getOtp}
+              disabled={!selectedAccountId || busy}
+              title={t("launcher.get_otp")}
+              className="flex h-10 w-10 items-center justify-center text-base text-[var(--on-accent)] transition-colors hover:bg-white/10 disabled:cursor-not-allowed"
             >
-              <path d="M2 4l3 3 3-3" />
-            </svg>
-          </button>
+              ↻
+            </button>
+            <button
+              onClick={() => setMoreOpen(!moreOpen)}
+              disabled={!selectedAccountId}
+              aria-label="More"
+              className="flex h-10 w-5 items-center justify-center border-l border-white/25 text-[var(--on-accent)] transition-colors hover:bg-white/10 disabled:cursor-not-allowed"
+            >
+              <svg
+                width="9"
+                height="9"
+                viewBox="0 0 10 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+              >
+                <path d="M2 4l3 3 3-3" />
+              </svg>
+            </button>
+          </div>
           {moreOpen && (
             <OtpMoreMenu
               onClose={() => setMoreOpen(false)}

--- a/src/features/launcher/PopupMenus.tsx
+++ b/src/features/launcher/PopupMenus.tsx
@@ -6,7 +6,7 @@ import { useConfigStore } from "../../lib/stores/config-store";
 const MENU_BASE =
   "z-50 animate-[ctxIn_0.15s_ease] rounded-[10px] border border-border bg-[var(--tb-card)] shadow-[0_8px_32px_rgba(0,0,0,0.3)]";
 const ITEM_BASE =
-  "flex w-full items-center text-left text-[var(--text)] transition-colors hover:bg-[rgba(232,162,58,0.08)] hover:text-accent";
+  "flex w-full items-center text-left text-[var(--text)] transition-colors hover:bg-[rgba(var(--accent-rgb),0.08)] hover:text-accent";
 
 /** Menu / item classes; the compact launcher gets a tighter menu so it doesn't
  *  dwarf the little window it pops over. */

--- a/src/features/login/LoginPage.tsx
+++ b/src/features/login/LoginPage.tsx
@@ -288,7 +288,7 @@ export function LoginPage() {
                 }
                 await doDirectLaunch();
               }}
-              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
             >
               {t("launcher.relaunch_confirm")}
             </button>

--- a/src/features/login/NormalLoginForm.tsx
+++ b/src/features/login/NormalLoginForm.tsx
@@ -330,7 +330,7 @@ export function NormalLoginForm({
           <button
             type="button"
             onClick={() => setShowCheckDetail(true)}
-            className="mb-3 flex w-full items-center gap-2 rounded-lg bg-[rgba(232,162,58,0.08)] px-3 py-2 text-left text-[11px] transition-colors hover:bg-[rgba(232,162,58,0.12)]"
+            className="mb-3 flex w-full items-center gap-2 rounded-lg bg-[rgba(var(--accent-rgb),0.08)] px-3 py-2 text-left text-[11px] transition-colors hover:bg-[rgba(var(--accent-rgb),0.12)]"
           >
             {classicCheck === null ? (
               <span className="text-text-dim">{t("login.classic_checking")}</span>
@@ -366,7 +366,7 @@ export function NormalLoginForm({
             autoCorrect="off"
             data-form-type="other"
             spellCheck={false}
-            className="w-full rounded-lg border border-border bg-[var(--surface)] px-3.5 py-2.5 pr-8 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(232,162,58,0.4)] focus:bg-[var(--surface-hover)] focus:shadow-[0_0_0_3px_var(--input-focus-ring)] focus:outline-none disabled:opacity-50"
+            className="w-full rounded-lg border border-border bg-[var(--surface)] px-3.5 py-2.5 pr-8 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(var(--accent-rgb),0.4)] focus:bg-[var(--surface-hover)] focus:shadow-[0_0_0_3px_var(--input-focus-ring)] focus:outline-none disabled:opacity-50"
           />
           {savedAccounts.length > 0 && (
             <button
@@ -399,8 +399,8 @@ export function NormalLoginForm({
                   }}
                   className={`group flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] text-[var(--text)] transition-colors ${
                     idx === highlightIdx
-                      ? "bg-[rgba(232,162,58,0.12)]"
-                      : "hover:bg-[rgba(232,162,58,0.08)]"
+                      ? "bg-[rgba(var(--accent-rgb),0.12)]"
+                      : "hover:bg-[rgba(var(--accent-rgb),0.08)]"
                   }`}
                 >
                   <button
@@ -451,7 +451,7 @@ export function NormalLoginForm({
           placeholder={t("login.password_placeholder")}
           autoComplete="new-password"
           data-form-type="other"
-          className="w-full rounded-lg border border-border bg-[var(--surface)] py-2.5 pr-9 pl-3.5 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(232,162,58,0.4)] focus:bg-[var(--surface-hover)] focus:shadow-[0_0_0_3px_var(--input-focus-ring)] focus:outline-none disabled:opacity-50"
+          className="w-full rounded-lg border border-border bg-[var(--surface)] py-2.5 pr-9 pl-3.5 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(var(--accent-rgb),0.4)] focus:bg-[var(--surface-hover)] focus:shadow-[0_0_0_3px_var(--input-focus-ring)] focus:outline-none disabled:opacity-50"
         />
       </div>
 
@@ -502,8 +502,8 @@ export function NormalLoginForm({
       <label
         className={`mb-3 flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${
           cafeMode
-            ? "border-[rgba(232,162,58,0.45)] bg-[rgba(232,162,58,0.08)]"
-            : "border-border bg-[var(--surface)] hover:border-[rgba(232,162,58,0.3)]"
+            ? "border-[rgba(var(--accent-rgb),0.45)] bg-[rgba(var(--accent-rgb),0.08)]"
+            : "border-border bg-[var(--surface)] hover:border-[rgba(var(--accent-rgb),0.3)]"
         }`}
       >
         <input
@@ -532,7 +532,7 @@ export function NormalLoginForm({
         <button
           type="submit"
           disabled={isLoading || !account.trim() || !password.trim()}
-          className="flex-1 rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-5 py-2.5 text-[11px] font-bold tracking-[2px] text-white uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:translate-y-[-1px] hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95 disabled:transform-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex-1 rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-5 py-2.5 text-[11px] font-bold tracking-[2px] text-[var(--on-accent)] uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:translate-y-[-1px] hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95 disabled:transform-none disabled:cursor-not-allowed disabled:opacity-40"
         >
           {isLoading
             ? t("login.logging_in")
@@ -747,7 +747,7 @@ export function NormalLoginForm({
               <button
                 type="button"
                 onClick={() => commands.openExternal(NGM_DOWNLOAD_URL).catch(() => {})}
-                className="flex w-full items-center justify-center gap-1.5 rounded-md bg-accent px-3 py-2 text-[12px] font-bold text-white shadow-[0_2px_10px_var(--accent-glow)] transition-opacity hover:opacity-90"
+                className="flex w-full items-center justify-center gap-1.5 rounded-md bg-accent px-3 py-2 text-[12px] font-bold text-[var(--on-accent)] shadow-[0_2px_10px_var(--accent-glow)] transition-opacity hover:opacity-90"
               >
                 ⬇ {t("login.classic_download")}
                 <span className="text-[10px] opacity-80">↗</span>
@@ -772,7 +772,7 @@ export function NormalLoginForm({
             <button
               type="button"
               onClick={() => setShowCheckDetail(false)}
-              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
             >
               {t("common.ok")}
             </button>

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -330,7 +330,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
         <button
           type="button"
           onClick={handleRefresh}
-          className="mt-4 w-full rounded-lg bg-accent px-4 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-white uppercase hover:opacity-90"
+          className="mt-4 w-full rounded-lg bg-accent px-4 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-[var(--on-accent)] uppercase hover:opacity-90"
         >
           {t("login.qr.refresh")}
         </button>

--- a/src/features/login/TotpForm.tsx
+++ b/src/features/login/TotpForm.tsx
@@ -153,7 +153,7 @@ export function TotpForm({ onBack }: TotpFormProps) {
               onKeyDown={(e) => handleKeyDown(i, e)}
               onPaste={i === 0 ? handlePaste : undefined}
               disabled={totp.isPending}
-              className="h-12 w-10 rounded-[10px] border-[1.5px] border-border bg-[var(--surface)] text-center font-mono text-[22px] font-extrabold text-accent caret-accent transition-all outline-none focus:border-accent focus:bg-[var(--surface-hover)] focus:shadow-[0_0_0_3px_var(--input-focus-ring),0_0_12px_rgba(232,162,58,0.1)] disabled:opacity-50"
+              className="h-12 w-10 rounded-[10px] border-[1.5px] border-border bg-[var(--surface)] text-center font-mono text-[22px] font-extrabold text-accent caret-accent transition-all outline-none focus:border-accent focus:bg-[var(--surface-hover)] focus:shadow-[0_0_0_3px_var(--input-focus-ring),0_0_12px_rgba(var(--accent-rgb),0.1)] disabled:opacity-50"
             />
           </span>
         ))}
@@ -178,7 +178,7 @@ export function TotpForm({ onBack }: TotpFormProps) {
         type="button"
         onClick={handleSubmit}
         disabled={totp.isPending || digits.join("").length < 6}
-        className="w-full rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-5 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-white uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95 disabled:opacity-40"
+        className="w-full rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-5 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-[var(--on-accent)] uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95 disabled:opacity-40"
       >
         {totp.isPending ? t("login.totp.verifying") : t("login.totp.submit")}
       </button>

--- a/src/features/login/VerifyForm.tsx
+++ b/src/features/login/VerifyForm.tsx
@@ -207,7 +207,7 @@ export function VerifyForm({
         </p>
         <button
           onClick={() => commands.openExternal(webVerifyUrl).catch(() => {})}
-          className="w-full rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-5 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-white uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95"
+          className="w-full rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-5 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-[var(--on-accent)] uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95"
         >
           {t("login.verify.open_browser")}
         </button>
@@ -230,7 +230,7 @@ export function VerifyForm({
     <div className="flex w-full flex-col">
       {/* Auth hint */}
       {(hintLabel || hintValue) && (
-        <div className="mb-3 rounded-lg bg-[rgba(232,162,58,0.06)] px-3 py-2">
+        <div className="mb-3 rounded-lg bg-[rgba(var(--accent-rgb),0.06)] px-3 py-2">
           {hintLabel && <div className="text-[12px] text-text-dim">{hintLabel}</div>}
           {hintValue && (
             <div className="mt-0.5 text-[12px] font-semibold text-[var(--text)]">{hintValue}</div>
@@ -250,7 +250,7 @@ export function VerifyForm({
           data-form-type="other"
           autoFocus
           disabled={submitting}
-          className="w-full rounded-lg border border-border bg-[var(--surface)] px-3.5 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(232,162,58,0.4)] focus:outline-none disabled:opacity-50"
+          className="w-full rounded-lg border border-border bg-[var(--surface)] px-3.5 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(var(--accent-rgb),0.4)] focus:outline-none disabled:opacity-50"
         />
       </div>
 
@@ -268,7 +268,7 @@ export function VerifyForm({
           autoComplete="off"
           data-form-type="other"
           disabled={submitting}
-          className="w-full rounded-lg border border-border bg-[var(--surface)] px-3.5 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(232,162,58,0.4)] focus:outline-none disabled:opacity-50"
+          className="w-full rounded-lg border border-border bg-[var(--surface)] px-3.5 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[12px] placeholder:text-text-dim focus:border-[rgba(var(--accent-rgb),0.4)] focus:outline-none disabled:opacity-50"
         />
       </div>
 
@@ -297,7 +297,7 @@ export function VerifyForm({
       <button
         onClick={handleSubmit}
         disabled={submitting || !authInfo.trim() || !captchaCode.trim()}
-        className="w-full rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-5 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-white uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95 disabled:opacity-40"
+        className="w-full rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-5 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-[var(--on-accent)] uppercase shadow-[0_2px_12px_var(--accent-glow)] transition-all hover:shadow-[0_4px_20px_var(--accent-glow)] active:scale-95 disabled:opacity-40"
       >
         {submitting ? t("login.verify.submitting") : t("login.verify.submit")}
       </button>

--- a/src/features/shared/AnnouncementBanner.tsx
+++ b/src/features/shared/AnnouncementBanner.tsx
@@ -15,7 +15,7 @@ export function AnnouncementBanner({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="flex h-[28px] shrink-0 items-center gap-2 border-b border-[rgba(232,162,58,0.2)] bg-[rgba(232,162,58,0.1)] pr-2 pl-3">
+    <div className="flex h-[28px] shrink-0 items-center gap-2 border-b border-[rgba(var(--accent-rgb),0.2)] bg-[rgba(var(--accent-rgb),0.1)] pr-2 pl-3">
       <button
         onClick={onOpen}
         className="flex min-w-0 flex-1 items-center gap-2 text-left transition-opacity hover:opacity-80"

--- a/src/features/shared/AnnouncementModal.tsx
+++ b/src/features/shared/AnnouncementModal.tsx
@@ -80,7 +80,7 @@ export function AnnouncementModal({
             <button
               disabled={locked}
               onClick={onMarkSeen}
-              className="mt-1 w-full rounded-lg bg-accent py-2.5 text-[13px] font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              className="mt-1 w-full rounded-lg bg-accent py-2.5 text-[13px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {locked
                 ? t("announcement.reading", { seconds: String(secondsLeft) })
@@ -89,7 +89,7 @@ export function AnnouncementModal({
           ) : (
             <button
               onClick={onClose}
-              className="mt-1 w-full rounded-lg bg-accent py-2.5 text-[13px] font-semibold text-white transition-opacity hover:opacity-90"
+              className="mt-1 w-full rounded-lg bg-accent py-2.5 text-[13px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
             >
               {t("announcement.close")}
             </button>

--- a/src/features/shared/BeanfunRenameDialog.tsx
+++ b/src/features/shared/BeanfunRenameDialog.tsx
@@ -78,7 +78,7 @@ export function BeanfunRenameDialog({
                 onConfirm();
               }}
               disabled={working}
-              className="flex-1 rounded-lg bg-accent py-2 text-[12px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              className="flex-1 rounded-lg bg-accent py-2 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90 disabled:opacity-50"
             >
               {working ? t("beanfun_rename.renaming") : t("beanfun_rename.confirm")}
             </button>

--- a/src/features/shared/CloseDialog.tsx
+++ b/src/features/shared/CloseDialog.tsx
@@ -51,7 +51,7 @@ export function CloseDialog({
             </button>
             <button
               onClick={() => onChoose("quit", remember)}
-              className="flex-1 rounded-lg bg-accent py-2 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+              className="flex-1 rounded-lg bg-accent py-2 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
             >
               {t("close_dialog.quit")}
             </button>

--- a/src/features/shared/OnboardingModal.tsx
+++ b/src/features/shared/OnboardingModal.tsx
@@ -38,7 +38,7 @@ export function OnboardingModal({ onClose }: OnboardingModalProps) {
       </div>
 
       <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[rgba(232,162,58,0.12)] text-[26px]">
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[rgba(var(--accent-rgb),0.12)] text-[26px]">
           {page.icon}
         </div>
         <h2 className="max-w-[420px] text-[15px] font-bold text-[var(--text)]">
@@ -86,7 +86,7 @@ export function OnboardingModal({ onClose }: OnboardingModalProps) {
         <button
           type="button"
           onClick={() => (last ? onClose() : setIndex((i) => i + 1))}
-          className="rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-4 py-1.5 text-[12px] font-bold text-white shadow-[0_2px_10px_var(--accent-glow)] transition-all hover:translate-y-[-1px] active:scale-95"
+          className="rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-4 py-1.5 text-[12px] font-bold text-[var(--on-accent)] shadow-[0_2px_10px_var(--accent-glow)] transition-all hover:translate-y-[-1px] active:scale-95"
         >
           {last ? t("onboarding.done") : t("onboarding.next")}
         </button>

--- a/src/features/shared/StatusBar.tsx
+++ b/src/features/shared/StatusBar.tsx
@@ -141,7 +141,7 @@ export function DownloadProgressBar() {
     <div className="mx-2 mb-0.5 rounded-md border border-border bg-[var(--surface)] px-2.5 py-1">
       <div className="mb-1 h-1 overflow-hidden rounded-full bg-[var(--bg)]">
         <div
-          className="h-full rounded-full bg-gradient-to-r from-accent to-[#c47a1a] transition-all duration-300"
+          className="h-full rounded-full bg-gradient-to-r from-accent to-[var(--accent-dark)] transition-all duration-300"
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/src/features/shared/UpdateDialog.tsx
+++ b/src/features/shared/UpdateDialog.tsx
@@ -105,14 +105,14 @@ export function UpdateDialog({ update, onClose }: Props) {
       <div className="flex flex-col gap-4">
         {/* Header */}
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-gradient-to-br from-accent to-[#c47a1a] text-lg font-bold text-white shadow-lg">
+          <div className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-gradient-to-br from-accent to-[var(--accent-dark)] text-lg font-bold text-[var(--on-accent)] shadow-lg">
             ↑
           </div>
           <div>
             <div className="text-sm font-semibold text-[var(--text)]">
               v{update.version}
               {update.isPrerelease && (
-                <span className="ml-2 rounded bg-[rgba(232,162,58,0.15)] px-1.5 py-0.5 text-[10px] text-accent">
+                <span className="ml-2 rounded bg-[rgba(var(--accent-rgb),0.15)] px-1.5 py-0.5 text-[10px] text-accent">
                   PRE
                 </span>
               )}
@@ -137,7 +137,7 @@ export function UpdateDialog({ update, onClose }: Props) {
           <div className="flex flex-col gap-2">
             <div className="h-2 overflow-hidden rounded-full bg-[var(--surface)]">
               <div
-                className="h-full rounded-full bg-gradient-to-r from-accent to-[#c47a1a] transition-all duration-300"
+                className="h-full rounded-full bg-gradient-to-r from-accent to-[var(--accent-dark)] transition-all duration-300"
                 style={{ width: `${percent}%` }}
               />
             </div>
@@ -196,7 +196,7 @@ export function UpdateDialog({ update, onClose }: Props) {
             </button>
             <button
               onClick={handleRestart}
-              className="rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-4 py-1.5 text-[12px] font-semibold text-white transition-all hover:opacity-90 active:scale-95"
+              className="rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-all hover:opacity-90 active:scale-95"
             >
               {t("update.restart")}
             </button>
@@ -221,7 +221,7 @@ export function UpdateDialog({ update, onClose }: Props) {
             <button
               onClick={handleDownload}
               disabled={!update.downloadUrl || !probeComplete}
-              className="rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-4 py-1.5 text-[12px] font-semibold text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+              className="rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
             >
               {t("update.download")}
             </button>

--- a/src/features/toolbox/AccountManagerTab.tsx
+++ b/src/features/toolbox/AccountManagerTab.tsx
@@ -74,7 +74,7 @@ export function AccountManagerTab() {
                   onClick={() => setExpandedId(isExpanded ? null : key)}
                   className="flex w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors hover:bg-[var(--surface-hover)]"
                 >
-                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-accent to-[#c47a1a] text-[11px] font-bold text-white">
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-accent to-[var(--accent-dark)] text-[11px] font-bold text-[var(--on-accent)]">
                     {a.account.charAt(0).toUpperCase()}
                   </div>
                   <div className="min-w-0 flex-1">
@@ -91,7 +91,7 @@ export function AccountManagerTab() {
                     </span>
                   )}
                   {a.rememberPassword && (
-                    <span className="shrink-0 rounded bg-[rgba(232,162,58,0.1)] px-1.5 py-0.5 text-[10.5px] font-semibold text-accent">
+                    <span className="shrink-0 rounded bg-[rgba(var(--accent-rgb),0.1)] px-1.5 py-0.5 text-[10.5px] font-semibold text-accent">
                       💾
                     </span>
                   )}

--- a/src/features/toolbox/AnnouncementsTab.tsx
+++ b/src/features/toolbox/AnnouncementsTab.tsx
@@ -25,7 +25,7 @@ export function AnnouncementsTab() {
           ← {t("shared.titlebar.back")}
         </button>
         <article className="overflow-hidden rounded-[10px] border border-[var(--tb-border)]">
-          <header className="flex items-center gap-2 border-b border-[var(--tb-border)] bg-[rgba(232,162,58,0.06)] px-4 py-2.5">
+          <header className="flex items-center gap-2 border-b border-[var(--tb-border)] bg-[rgba(var(--accent-rgb),0.06)] px-4 py-2.5">
             <span className="text-[13px]">📢</span>
             <span className="flex-1 text-[13px] font-bold text-[var(--text)]">
               {t("announcement.title")}

--- a/src/features/toolbox/GameDownloadModal.tsx
+++ b/src/features/toolbox/GameDownloadModal.tsx
@@ -36,7 +36,7 @@ function DownloadRow({ item }: { item: GameDownloadDto }) {
           </button>
           <button
             onClick={() => openExternal(item.url)}
-            className="rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-2.5 py-1 text-[11px] font-semibold text-white transition-opacity hover:opacity-90 active:scale-95"
+            className="rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-2.5 py-1 text-[11px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90 active:scale-95"
           >
             {t("toolbox.download.download")}
           </button>

--- a/src/features/toolbox/ImportExportBar.tsx
+++ b/src/features/toolbox/ImportExportBar.tsx
@@ -177,7 +177,7 @@ export function ImportExportBar({ onImported }: { onImported: () => void }) {
             <button
               onClick={doExport}
               disabled={busy}
-              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90 disabled:opacity-50"
             >
               {t("data.export_btn")}
             </button>
@@ -226,7 +226,7 @@ export function ImportExportBar({ onImported }: { onImported: () => void }) {
             <button
               onClick={() => disposalPath && runImport(disposalPath, disposal)}
               disabled={busy}
-              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90 disabled:opacity-50"
             >
               {t("data.import_btn")}
             </button>
@@ -264,7 +264,7 @@ export function ImportExportBar({ onImported }: { onImported: () => void }) {
             <button
               onClick={() => importPath && runImport(importPath, disposal, importPass)}
               disabled={busy || !importPass}
-              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              className="rounded-lg bg-accent px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90 disabled:opacity-50"
             >
               {t("data.import_btn")}
             </button>

--- a/src/features/toolbox/SettingsTab.tsx
+++ b/src/features/toolbox/SettingsTab.tsx
@@ -6,6 +6,7 @@ import { useUiStore, announcementBarShown } from "../../lib/stores/ui-store";
 import { commands } from "../../lib/tauri";
 import { Toggle } from "../../components/Toggle";
 import { Section, Row, RowButton, RowValue, Segmented } from "./ToolboxUi";
+import { ACCENT_PRESETS, DEFAULT_ACCENT, applyAccent, isHexColor } from "../../lib/accent";
 import type { ThemeMode, Language } from "../../lib/stores/ui-store";
 
 const THEMES: { value: ThemeMode; labelKey: string }[] = [
@@ -92,6 +93,18 @@ export function SettingsTab() {
     setConfig.mutate({ key: "updateChannel", value: channel });
   }
 
+  // Applied at once so the page previews the colour; persisted as "" for the
+  // default so config.ini stays clean.
+  function handleAccentChange(hex: string) {
+    const value = hex.toLowerCase() === DEFAULT_ACCENT ? "" : hex.toLowerCase();
+    applyAccent(value);
+    useConfigStore.getState().updateConfigField("accentColor", value);
+    setConfig.mutate({ key: "accentColor", value });
+  }
+  const currentAccent =
+    config?.accentColor && isHexColor(config.accentColor) ? config.accentColor : DEFAULT_ACCENT;
+  const accentIsPreset = ACCENT_PRESETS.some((p) => p.hex === currentAccent);
+
   function handleDefaultLoginViewChange(view: DefaultLoginView) {
     useConfigStore.getState().updateConfigField("defaultLoginView", view);
     setConfig.mutate({ key: "defaultLoginView", value: view });
@@ -135,6 +148,45 @@ export function SettingsTab() {
             value={config?.language ?? "zh-TW"}
             onChange={handleLanguageChange}
           />
+        </Row>
+        <Row label={t("settings.accent_color")}>
+          <div className="flex items-center gap-1.5">
+            {ACCENT_PRESETS.map((p) => {
+              const active = p.hex === currentAccent;
+              return (
+                <button
+                  key={p.key}
+                  type="button"
+                  title={t(`settings.accent.${p.key}`)}
+                  onClick={() => handleAccentChange(p.hex)}
+                  style={{ background: p.hex }}
+                  className={`h-5 w-5 rounded-full transition-transform hover:scale-110 ${
+                    active
+                      ? "ring-2 ring-[var(--text)] ring-offset-2 ring-offset-[var(--tb-card)]"
+                      : "ring-1 ring-black/10"
+                  }`}
+                />
+              );
+            })}
+            {/* Custom: the native colour picker behind a rainbow swatch */}
+            <label
+              title={t("settings.accent.custom")}
+              className={`relative flex h-5 w-5 cursor-pointer items-center justify-center rounded-full text-[10px] font-bold transition-transform hover:scale-110 ${
+                accentIsPreset
+                  ? "bg-[conic-gradient(#f87171,#facc15,#4ade80,#60a5fa,#c084fc,#f87171)] text-white ring-1 ring-black/10"
+                  : "text-[var(--on-accent)] ring-2 ring-[var(--text)] ring-offset-2 ring-offset-[var(--tb-card)]"
+              }`}
+              style={accentIsPreset ? undefined : { background: currentAccent }}
+            >
+              <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.6)]">+</span>
+              <input
+                type="color"
+                value={currentAccent}
+                onChange={(e) => handleAccentChange(e.target.value)}
+                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+              />
+            </label>
+          </div>
         </Row>
         <Row label={t("settings.compact_ui")} hint={t("settings.compact_ui_desc")}>
           <Toggle

--- a/src/features/toolbox/ToolboxPage.tsx
+++ b/src/features/toolbox/ToolboxPage.tsx
@@ -44,7 +44,7 @@ export function ToolboxPage() {
               title={t(tab.labelKey)}
               className={`mx-1.5 my-0.5 flex flex-col items-center gap-0.5 rounded-lg px-1 py-1.5 text-[9px] font-semibold tracking-[0.3px] transition-all hover:bg-[var(--surface)] hover:text-[var(--text)] ${
                 activeTab === tab.key
-                  ? "bg-[rgba(232,162,58,0.1)] text-accent shadow-[inset_0_0_0_1px_rgba(232,162,58,0.25)]"
+                  ? "bg-[rgba(var(--accent-rgb),0.1)] text-accent shadow-[inset_0_0_0_1px_rgba(var(--accent-rgb),0.25)]"
                   : "text-text-dim"
               }`}
             >
@@ -57,7 +57,7 @@ export function ToolboxPage() {
               onClick={() => setActiveTab(tab.key)}
               className={`flex items-center gap-2 border-l-[3px] px-[18px] py-2.5 text-left text-[12px] font-semibold tracking-[0.5px] transition-all hover:translate-y-[-1px] hover:bg-[var(--surface)] hover:text-[var(--text)] ${
                 activeTab === tab.key
-                  ? "border-l-accent bg-[rgba(232,162,58,0.05)] text-accent"
+                  ? "border-l-accent bg-[rgba(var(--accent-rgb),0.05)] text-accent"
                   : "border-l-transparent text-text-dim"
               }`}
             >

--- a/src/features/toolbox/ToolboxUi.tsx
+++ b/src/features/toolbox/ToolboxUi.tsx
@@ -47,7 +47,9 @@ export function Row({
 }) {
   const inner = (
     <>
-      <div className="min-w-0 flex-1">
+      {/* min-w keeps a long right-side value (a wrapping path) from crushing
+          the label into a one-character-per-line column. */}
+      <div className="min-w-[76px] flex-1">
         <div className="text-[11.5px] font-medium text-[var(--text)]">{label}</div>
         {hint && <div className="mt-0.5 text-[10.5px] leading-snug text-text-faint">{hint}</div>}
       </div>
@@ -125,10 +127,16 @@ export function RowButton({
   );
 }
 
-/** A value shown on a row's right side (paths, read-only info). */
+/** A value shown on a row's right side (paths, read-only info). Wraps rather
+ *  than truncates — a game path is only useful when all of it is readable. */
 export function RowValue({ children, mono }: { children: ReactNode; mono?: boolean }) {
   return (
-    <span className={`max-w-[220px] truncate text-[11px] text-text-dim ${mono ? "font-mono" : ""}`}>
+    <span
+      title={typeof children === "string" ? children : undefined}
+      className={`max-w-[300px] min-w-0 text-right text-[11px] leading-snug break-all text-text-dim ${
+        mono ? "font-mono" : ""
+      }`}
+    >
       {children}
     </span>
   );

--- a/src/features/toolbox/ToolboxUi.tsx
+++ b/src/features/toolbox/ToolboxUi.tsx
@@ -87,7 +87,7 @@ export function Segmented<T extends string>({
             i < options.length - 1 ? "border-r border-[var(--tb-border)]" : ""
           } ${
             value === o.value
-              ? "bg-gradient-to-br from-accent to-[#c47a1a] text-white"
+              ? "bg-gradient-to-br from-accent to-[var(--accent-dark)] text-[var(--on-accent)]"
               : "bg-transparent text-text-dim hover:bg-[var(--surface-hover)] hover:text-[var(--text)]"
           }`}
         >

--- a/src/features/toolbox/ToolsTab.tsx
+++ b/src/features/toolbox/ToolsTab.tsx
@@ -217,7 +217,7 @@ export function ToolsTab() {
             </button>
             <button
               onClick={doCleanup}
-              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
             >
               {t("common.confirm")}
             </button>
@@ -242,7 +242,7 @@ export function ToolsTab() {
             </button>
             <button
               onClick={doResetWebview}
-              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90"
+              className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
             >
               {t("toolbox.tools.reset_webview_restart")}
             </button>

--- a/src/features/toolbox/WebLaunchTab.tsx
+++ b/src/features/toolbox/WebLaunchTab.tsx
@@ -256,7 +256,7 @@ export function WebLaunchTab() {
       <div
         className={`flex items-center justify-between rounded-[12px] border px-4 py-3.5 transition-colors ${
           enabled
-            ? "border-[rgba(232,162,58,0.4)] bg-[rgba(232,162,58,0.06)]"
+            ? "border-[rgba(var(--accent-rgb),0.4)] bg-[rgba(var(--accent-rgb),0.06)]"
             : "border-[var(--tb-border)] bg-[var(--tb-card)]"
         }`}
       >
@@ -376,7 +376,7 @@ export function WebLaunchTab() {
               !status?.gamaniaInstalled && (
                 <button
                   onClick={() => openExternal(GAMANIA_DOWNLOAD_URL)}
-                  className="shrink-0 rounded-lg border border-accent px-2.5 py-1 text-[11px] font-semibold text-accent transition-colors hover:bg-[rgba(232,162,58,0.08)]"
+                  className="shrink-0 rounded-lg border border-accent px-2.5 py-1 text-[11px] font-semibold text-accent transition-colors hover:bg-[rgba(var(--accent-rgb),0.08)]"
                 >
                   {t("web_launch.gamania_download")}
                 </button>
@@ -408,7 +408,7 @@ export function WebLaunchTab() {
           <button
             onClick={handleTest}
             disabled={testing !== null}
-            className="mt-0.5 self-start rounded-lg bg-gradient-to-br from-accent to-[#c47a1a] px-4 py-1.5 text-[12px] font-semibold text-white transition-opacity hover:opacity-90 active:scale-95 disabled:opacity-50"
+            className="mt-0.5 self-start rounded-lg bg-gradient-to-br from-accent to-[var(--accent-dark)] px-4 py-1.5 text-[12px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90 active:scale-95 disabled:opacity-50"
           >
             {testing !== null
               ? testing === "game"

--- a/src/lib/accent.ts
+++ b/src/lib/accent.ts
@@ -1,0 +1,66 @@
+/**
+ * User-selectable accent colour. The stylesheet defines the maple-orange
+ * default as CSS variables; picking another colour overrides them inline on
+ * <html>, and clearing it removes the overrides so the stylesheet wins again.
+ */
+
+export const DEFAULT_ACCENT = "#e8a23a";
+
+/** Built-in swatches. Chosen so white text stays readable on a filled button. */
+export const ACCENT_PRESETS: { key: string; hex: string }[] = [
+  { key: "maple", hex: DEFAULT_ACCENT },
+  { key: "blue", hex: "#3b82f6" },
+  { key: "teal", hex: "#14b8a6" },
+  { key: "green", hex: "#22c55e" },
+  { key: "purple", hex: "#a855f7" },
+  { key: "pink", hex: "#ec4899" },
+  { key: "red", hex: "#ef4444" },
+];
+
+export function isHexColor(v: string): boolean {
+  return /^#[0-9a-f]{6}$/i.test(v);
+}
+
+type Rgb = [number, number, number];
+
+function parse(hex: string): Rgb {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function toHex(rgb: Rgb): string {
+  return "#" + rgb.map((c) => Math.round(c).toString(16).padStart(2, "0")).join("");
+}
+
+/** Mix towards black by `amount` (0..1). */
+function darken(rgb: Rgb, amount: number): Rgb {
+  return [rgb[0] * (1 - amount), rgb[1] * (1 - amount), rgb[2] * (1 - amount)];
+}
+
+/** WCAG relative luminance (0 = black, 1 = white). */
+function luminance([r, g, b]: Rgb): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+const VARS = ["--accent", "--accent-rgb", "--accent-dark", "--accent-deep", "--on-accent"];
+
+/** Apply an accent colour app-wide; empty or invalid restores the default. */
+export function applyAccent(hex: string): void {
+  const root = document.documentElement;
+  const value = hex.trim().toLowerCase();
+  if (!isHexColor(value) || value === DEFAULT_ACCENT) {
+    for (const v of VARS) root.style.removeProperty(v);
+    return;
+  }
+  const rgb = parse(value);
+  root.style.setProperty("--accent", value);
+  root.style.setProperty("--accent-rgb", rgb.map(Math.round).join(", "));
+  root.style.setProperty("--accent-dark", toHex(darken(rgb, 0.15)));
+  root.style.setProperty("--accent-deep", toHex(darken(rgb, 0.25)));
+  // Light accents (yellow, lime…) need dark text on top to stay legible.
+  root.style.setProperty("--on-accent", luminance(rgb) > 0.55 ? "#1d1d1f" : "#ffffff");
+}

--- a/src/lib/accent.ts
+++ b/src/lib/accent.ts
@@ -101,8 +101,10 @@ export function applyAccent(hex: string): void {
   set("--nav-user", 23, 5.1);
   set("--card-user", 11, 8.8);
   set("--input-user", 14, 6.9);
-  set("--bg-user-light", 11, 96.5);
-  set("--nav-user-light", 8, 90);
-  set("--card-user-light", 20, 99);
-  set("--input-user-light", 20, 97.5);
+  // The light palette leans harder into the hue — near-white carries far less
+  // colour than near-black, so the same saturation reads as no tint at all.
+  set("--bg-user-light", 42, 95);
+  set("--nav-user-light", 30, 88);
+  set("--card-user-light", 55, 98.5);
+  set("--input-user-light", 45, 96.5);
 }

--- a/src/lib/accent.ts
+++ b/src/lib/accent.ts
@@ -46,7 +46,34 @@ function luminance([r, g, b]: Rgb): number {
   return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
 }
 
-const VARS = ["--accent", "--accent-rgb", "--accent-dark", "--accent-deep", "--on-accent"];
+/** Hue in degrees (0..360) of an sRGB colour. */
+function hue([r, g, b]: Rgb): number {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) return 0;
+  const d = max - min;
+  let h: number;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  return Math.round(((h * 60) % 360 < 0 ? h * 60 + 360 : h * 60) * 10) / 10;
+}
+
+const VARS = [
+  "--accent",
+  "--accent-rgb",
+  "--accent-dark",
+  "--accent-deep",
+  "--on-accent",
+  "--bg-user",
+  "--nav-user",
+  "--card-user",
+  "--input-user",
+  "--bg-user-light",
+  "--nav-user-light",
+  "--card-user-light",
+  "--input-user-light",
+];
 
 /** Apply an accent colour app-wide; empty or invalid restores the default. */
 export function applyAccent(hex: string): void {
@@ -63,4 +90,19 @@ export function applyAccent(hex: string): void {
   root.style.setProperty("--accent-deep", toHex(darken(rgb, 0.25)));
   // Light accents (yellow, lime…) need dark text on top to stay legible.
   root.style.setProperty("--on-accent", luminance(rgb) > 0.55 ? "#1d1d1f" : "#ffffff");
+
+  // Tint the solid backgrounds with the accent's hue. Saturation/lightness
+  // mirror the default palette (whose near-blacks carry S≈25%, L≈5%), so only
+  // the temperature changes — contrast stays exactly as designed.
+  const h = hue(rgb);
+  const set = (name: string, s: number, l: number) =>
+    root.style.setProperty(name, `hsl(${h} ${s}% ${l}%)`);
+  set("--bg-user", 25, 4.7);
+  set("--nav-user", 23, 5.1);
+  set("--card-user", 11, 8.8);
+  set("--input-user", 14, 6.9);
+  set("--bg-user-light", 11, 96.5);
+  set("--nav-user-light", 8, 90);
+  set("--card-user-light", 20, 99);
+  set("--input-user-light", 20, 97.5);
 }

--- a/src/lib/hooks/use-config.ts
+++ b/src/lib/hooks/use-config.ts
@@ -58,6 +58,7 @@ const KEY_MAP: Record<string, string> = {
   defaultLoginView: "default_login_view",
   githubHosts: "github_hosts",
   compactUi: "compact_ui",
+  accentColor: "accent_color",
   __reset__: "__reset__",
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,6 +82,7 @@ export interface AppConfigDto {
   defaultLoginView: "normal" | "qr";
   githubHosts: boolean;
   compactUi: boolean;
+  accentColor: string;
 }
 
 /** Result of the startup "rename exe to Beanfun.exe" check (China-IP users). */

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -466,5 +466,14 @@
   "settings.section.launch": "Launch",
   "settings.section.privacy": "Privacy",
   "settings.section.window": "Window",
-  "settings.section.debug": "Debugging"
+  "settings.section.debug": "Debugging",
+  "settings.accent_color": "Accent colour",
+  "settings.accent.maple": "Maple orange (default)",
+  "settings.accent.blue": "Blue",
+  "settings.accent.teal": "Teal",
+  "settings.accent.green": "Green",
+  "settings.accent.purple": "Purple",
+  "settings.accent.pink": "Pink",
+  "settings.accent.red": "Red",
+  "settings.accent.custom": "Custom…"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -466,5 +466,14 @@
   "settings.section.launch": "启动",
   "settings.section.privacy": "隐私",
   "settings.section.window": "窗口",
-  "settings.section.debug": "调试"
+  "settings.section.debug": "调试",
+  "settings.accent_color": "主题色",
+  "settings.accent.maple": "枫叶橙（默认）",
+  "settings.accent.blue": "蓝",
+  "settings.accent.teal": "青",
+  "settings.accent.green": "绿",
+  "settings.accent.purple": "紫",
+  "settings.accent.pink": "粉红",
+  "settings.accent.red": "红",
+  "settings.accent.custom": "自定义…"
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -466,5 +466,14 @@
   "settings.section.launch": "啟動",
   "settings.section.privacy": "隱私",
   "settings.section.window": "視窗",
-  "settings.section.debug": "除錯"
+  "settings.section.debug": "除錯",
+  "settings.accent_color": "主題色",
+  "settings.accent.maple": "楓葉橙（預設）",
+  "settings.accent.blue": "藍",
+  "settings.accent.teal": "青",
+  "settings.accent.green": "綠",
+  "settings.accent.purple": "紫",
+  "settings.accent.pink": "粉紅",
+  "settings.accent.red": "紅",
+  "settings.accent.custom": "自訂…"
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
+import "@fontsource-variable/noto-sans-tc";
 import "./styles/globals.css";
 
 const queryClient = new QueryClient({

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -73,7 +73,11 @@
   body {
     background: var(--bg);
     color: var(--text);
+    /* The bundled Noto Sans TC renders every script (Latin included) so the
+       look no longer depends on which CJK font a machine happens to have —
+       the system stack below is only a safety net. */
     font-family:
+      "Noto Sans TC Variable",
       "Segoe UI",
       "Microsoft JhengHei UI",
       "Microsoft JhengHei",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,8 +14,18 @@
 
 @layer base {
   :root {
+    /* Accent family. `--accent-rgb` is the same colour as a bare triplet so
+       Tailwind arbitrary values can do rgba(var(--accent-rgb),0.08). The
+       darker pair ends the gradients. All four are overridden at runtime by
+       applyAccent() when the user picks their own colour. */
     --accent: #e8a23a;
-    --accent-glow: rgba(232, 162, 58, 0.35);
+    --accent-rgb: 232, 162, 58;
+    --accent-dark: #c47a1a;
+    --accent-deep: #c46a00;
+    /* Text on top of an accent fill — white for the default orange, flipped
+       to dark by applyAccent() for light accents. */
+    --on-accent: #ffffff;
+    --accent-glow: rgba(var(--accent-rgb), 0.35);
     --danger: #e81123;
     --radius: 10px;
     --bg: #090b0f;
@@ -25,8 +35,8 @@
     --text: rgba(255, 255, 255, 0.88);
     --text-dim: rgba(255, 255, 255, 0.45);
     --text-faint: rgba(255, 255, 255, 0.22);
-    --glow-bg: rgba(232, 162, 58, 0.06);
-    --input-focus-ring: rgba(232, 162, 58, 0.08);
+    --glow-bg: rgba(var(--accent-rgb), 0.06);
+    --input-focus-ring: rgba(var(--accent-rgb), 0.08);
     --tb-bg: #090b0f;
     --tb-nav-bg: #0a0c10;
     --tb-card: #141619;
@@ -42,8 +52,8 @@
     --text: #1d1d1f;
     --text-dim: #86868b;
     --text-faint: #b0b0b5;
-    --glow-bg: rgba(232, 162, 58, 0.04);
-    --input-focus-ring: rgba(232, 162, 58, 0.12);
+    --glow-bg: rgba(var(--accent-rgb), 0.04);
+    --input-focus-ring: rgba(var(--accent-rgb), 0.12);
     --tb-bg: #f5f5f7;
     --tb-nav-bg: #e4e4e8;
     --tb-card: #ffffff;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -75,9 +75,16 @@
     color: var(--text);
     font-family:
       "Segoe UI",
+      "Microsoft JhengHei UI",
+      "Microsoft JhengHei",
+      "Microsoft YaHei UI",
+      "Microsoft YaHei",
+      "PingFang TC",
+      "Noto Sans TC",
       system-ui,
       -apple-system,
       sans-serif;
+    -webkit-font-smoothing: antialiased;
     font-size: 15px;
     height: 100vh;
     overflow: hidden;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -28,7 +28,10 @@
     --accent-glow: rgba(var(--accent-rgb), 0.35);
     --danger: #e81123;
     --radius: 10px;
-    --bg: #090b0f;
+    /* Solid backgrounds go through a *-user indirection: applyAccent() fills
+       the user vars with hue-tinted values (per theme), and clearing the
+       accent removes them so these defaults win again. */
+    --bg: var(--bg-user, #090b0f);
     --surface: rgba(255, 255, 255, 0.04);
     --surface-hover: rgba(255, 255, 255, 0.07);
     --border: rgba(255, 255, 255, 0.08);
@@ -37,15 +40,15 @@
     --text-faint: rgba(255, 255, 255, 0.22);
     --glow-bg: rgba(var(--accent-rgb), 0.06);
     --input-focus-ring: rgba(var(--accent-rgb), 0.08);
-    --tb-bg: #090b0f;
-    --tb-nav-bg: #0a0c10;
-    --tb-card: #141619;
+    --tb-bg: var(--bg-user, #090b0f);
+    --tb-nav-bg: var(--nav-user, #0a0c10);
+    --tb-card: var(--card-user, #141619);
     --tb-border: rgba(255, 255, 255, 0.1);
-    --tb-input-bg: #0f1114;
+    --tb-input-bg: var(--input-user, #0f1114);
   }
 
   .light {
-    --bg: #f5f5f7;
+    --bg: var(--bg-user-light, #f5f5f7);
     --surface: rgba(0, 0, 0, 0.03);
     --surface-hover: rgba(0, 0, 0, 0.05);
     --border: rgba(0, 0, 0, 0.1);
@@ -54,11 +57,11 @@
     --text-faint: #b0b0b5;
     --glow-bg: rgba(var(--accent-rgb), 0.04);
     --input-focus-ring: rgba(var(--accent-rgb), 0.12);
-    --tb-bg: #f5f5f7;
-    --tb-nav-bg: #e4e4e8;
-    --tb-card: #ffffff;
+    --tb-bg: var(--bg-user-light, #f5f5f7);
+    --tb-nav-bg: var(--nav-user-light, #e4e4e8);
+    --tb-card: var(--card-user-light, #ffffff);
     --tb-border: rgba(0, 0, 0, 0.1);
-    --tb-input-bg: #f8f8fa;
+    --tb-input-bg: var(--input-user-light, #f8f8fa);
   }
 
   * {


### PR DESCRIPTION
## What

Settings â†’ Appearance â†’ Accent colour: seven preset swatches (maple orange default, blue, teal, green, purple, pink, red) plus a custom colour picker. Persisted as `accent_color` in config.ini (empty = default).

- Every hardcoded orange (`rgba(232,162,58,â€¦)`, `#c47a1a`, `#c46a00`) is now a CSS variable; `applyAccent()` overrides them inline on `<html>` and derives the darker gradient stops
- Text on accent fills uses `--on-accent`, flipped to dark automatically for light accents (e.g. yellow)
- Semantic colours (green online, red banned/danger) are unchanged
- The solid backgrounds (window, cards, nav, inputs) take on the accent hue too — same lightness/contrast as the defaults, only the temperature shifts, in both themes

## Why

Lets players make the launcher theirs without touching the rest of the design.

## How to test

1. Toolbox â†’ Settings â†’ Accent colour: click a swatch â€” the whole app recolours at once, in both dark and light theme.
2. Click the rainbow `+` swatch, pick a pale colour (e.g. yellow): button text turns dark.
3. Restart: the colour persists (`accent_color = #rrggbb` in config.ini); pick maple orange to clear it.

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes
- [x] Tested locally with `cargo tauri dev`
- [x] No breaking changes to existing features

