### PR TITLE
fix(paths): handle non-ASCII Windows profile names

### DIFF
--- a/installer/hooks.nsh
+++ b/installer/hooks.nsh
@@ -1,0 +1,38 @@
+; MapleLink NSIS installer hooks.
+;
+; Everything MapleLink writes lives under $INSTDIR or the per-user app data
+; directory, with one exception: Locale Remulator cannot load its hook DLL from
+; a path outside the ANSI code page (it round-trips that path through
+; GetModuleFileNameA into `rundll32.exe "%hs",#1`), so when the Windows profile
+; name is not ASCII the LR files are extracted to an ASCII root instead — see
+; ASCII_ROOTS / ASCII_FALLBACK_DIR in src-tauri/src/services/lr_service.rs.
+;
+; That directory is outside $INSTDIR, so the uninstaller has to remove it
+; explicitly. Only the "lr" folder we wrote is deleted, then its parent if that
+; leaves it empty — never a recursive delete of a root we did not create.
+; Failures are ignored: an unelevated per-user uninstall may not be allowed to
+; touch %ProgramData%, and a leftover folder is not worth a failed uninstall.
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  SetDetailsPrint textonly
+  ClearErrors
+
+  ; %ProgramData%\MapleLink\lr  (also covers %ALLUSERSPROFILE%, the same folder)
+  ReadEnvStr $R0 "ProgramData"
+  StrCmp $R0 "" maplelink_lr_systemdrive
+  IfFileExists "$R0\MapleLink\lr\*.*" 0 maplelink_lr_systemdrive
+  RMDir /r "$R0\MapleLink\lr"
+  RMDir "$R0\MapleLink"
+
+maplelink_lr_systemdrive:
+  ; %SystemDrive%\MapleLink\lr  (used when %ProgramData% was not writable)
+  ReadEnvStr $R0 "SystemDrive"
+  StrCmp $R0 "" maplelink_lr_done
+  IfFileExists "$R0\MapleLink\lr\*.*" 0 maplelink_lr_done
+  RMDir /r "$R0\MapleLink\lr"
+  RMDir "$R0\MapleLink"
+
+maplelink_lr_done:
+  ClearErrors
+  SetDetailsPrint both
+!macroend

--- a/src-tauri/src/services/cafe_service.rs
+++ b/src-tauri/src/services/cafe_service.rs
@@ -71,19 +71,7 @@ fn schedule_webview_wipe() {
         return;
     }
 
-    // Single-quote the paths for PowerShell; a data-dir path can't contain a
-    // single quote (it's under a fixed identifier), so no escaping is needed.
-    let removes = targets
-        .iter()
-        .map(|t| {
-            format!("Remove-Item -LiteralPath '{t}' -Recurse -Force -ErrorAction SilentlyContinue")
-        })
-        .collect::<Vec<_>>()
-        .join("; ");
-    // Wait for us (and the webview children that exit with us) to release the
-    // lock, then remove the folders. The brief sleep covers child teardown.
-    let script =
-        format!("Wait-Process -Id {pid} -ErrorAction SilentlyContinue; Start-Sleep -Milliseconds 800; {removes}");
+    let script = webview_wipe_script(pid, &targets);
 
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     const DETACHED_PROCESS: u32 = 0x0000_0008;
@@ -109,3 +97,72 @@ fn schedule_webview_wipe() {
 
 #[cfg(not(target_os = "windows"))]
 fn schedule_webview_wipe() {}
+
+/// The PowerShell one-liner the wipe helper runs: wait for us to exit, let the
+/// webview children follow, then delete each folder.
+///
+/// Paths are single-quoted, and any single quote inside them is doubled — the
+/// literal-string escape. The tail of each path is a fixed identifier but the
+/// head is the user profile, which can hold anything a Windows account name can,
+/// apostrophes included. Unescaped, the script is a *parse* error: PowerShell
+/// then runs none of it, not even the removes that would have been fine.
+fn webview_wipe_script(pid: u32, targets: &[String]) -> String {
+    let removes = targets
+        .iter()
+        .map(|t| {
+            let quoted = t.replace('\'', "''");
+            format!(
+                "Remove-Item -LiteralPath '{quoted}' -Recurse -Force -ErrorAction SilentlyContinue"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    format!(
+        "Wait-Process -Id {pid} -ErrorAction SilentlyContinue; \
+         Start-Sleep -Milliseconds 800; {removes}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wipe_script_quotes_each_target() {
+        let script = webview_wipe_script(
+            42,
+            &[r"C:\Users\bob\AppData\Local\com.maplelink.app\EBWebView".to_string()],
+        );
+        assert!(script.contains("Wait-Process -Id 42"));
+        assert!(script
+            .contains(r"-LiteralPath 'C:\Users\bob\AppData\Local\com.maplelink.app\EBWebView'"));
+    }
+
+    #[test]
+    fn wipe_script_escapes_an_apostrophe_in_the_profile_name() {
+        let script = webview_wipe_script(1, &[r"C:\Users\O'Brien\AppData\Local\x".to_string()]);
+        assert!(
+            script.contains(r"'C:\Users\O''Brien\AppData\Local\x'"),
+            "apostrophe not doubled: {script}"
+        );
+        // Every quote in the script must pair up, or PowerShell won't parse it.
+        assert_eq!(script.matches('\'').count() % 2, 0, "unbalanced: {script}");
+    }
+
+    #[test]
+    fn wipe_script_keeps_non_ascii_profile_names_verbatim() {
+        // The command line reaches PowerShell as UTF-16, so CJK and full-width
+        // punctuation need no special handling — but they must not be mangled.
+        let path = r"C:\Users\简体（管理員）\AppData\Local\com.maplelink.app\EBWebView";
+        let script = webview_wipe_script(1, &[path.to_string()]);
+        assert!(script.contains(path), "path altered: {script}");
+    }
+
+    #[test]
+    fn wipe_script_joins_multiple_targets() {
+        let script = webview_wipe_script(1, &["a".to_string(), "b".to_string()]);
+        assert_eq!(script.matches("Remove-Item").count(), 2);
+        assert!(script.contains("SilentlyContinue; Remove-Item -LiteralPath 'b'"));
+    }
+}

--- a/src-tauri/src/services/lr_service.rs
+++ b/src-tauri/src/services/lr_service.rs
@@ -11,6 +11,15 @@ use crate::core::error::ProcessError;
 /// The LR profile GUID for "Run in Taiwan (Admin)" in `LRConfig.xml`.
 pub const LR_PROFILE_GUID: &str = "ef3e7b42-a87c-4c07-ae3e-eeebeef12762";
 
+/// Environment roots that are ASCII on every Windows install, used when the
+/// user profile isn't — see [`lr_dir_candidates`]. `%ProgramData%` first: it is
+/// writable without elevation and is where shared app data belongs.
+const ASCII_ROOTS: [&str; 3] = ["ProgramData", "ALLUSERSPROFILE", "SystemDrive"];
+
+/// Folder we create under an [`ASCII_ROOTS`] entry. Kept in sync with the
+/// uninstaller (`installer/hooks.nsh`), which deletes it.
+const ASCII_FALLBACK_DIR: &str = "MapleLink";
+
 /// Embedded LR files — compiled directly into the binary so a standalone
 /// `maplelink.exe` works without needing a `resources/lr/` folder alongside it.
 const EMBEDDED_LR: &[(&str, &[u8])] = &[
@@ -147,8 +156,16 @@ async fn sync_lr_file(
 ///
 /// So: `<app_data_dir>/lr` when the profile name is ASCII (nearly everyone,
 /// unchanged); its 8.3 short form next, which names the very same directory and
-/// so needs no migration; and finally two roots that are ASCII on every Windows
-/// install, for volumes with 8.3 name creation switched off.
+/// so needs no migration; and then [`ASCII_ROOTS`], which are ASCII on every
+/// Windows install.
+///
+/// Do not count on the short form. Windows only generates an 8.3 alias for a
+/// name it cannot already express in the *OEM* code page — and on exactly the
+/// machines that hit this bug (a Chinese Windows, OEM 936/950) a Chinese folder
+/// name is expressible, so `GetShortPathNameW` hands the name straight back
+/// unchanged. `C:\Users\小明` shortens to `C:\Users\C3DD~1` on an English
+/// install and to `C:\Users\小明` on a Chinese one. The [`ASCII_ROOTS`] fallback
+/// is what actually carries these users.
 ///
 /// The plain long path is always last so a failure is a failed launch with the
 /// real path in the log, not an empty candidate list.
@@ -162,13 +179,13 @@ pub fn lr_dir_candidates(app_data_dir: &std::path::Path) -> Vec<PathBuf> {
 
     let mut candidates = Vec::new();
     // Same directory, ASCII alias — only exists once `primary` does, which is
-    // why the caller creates it before asking.
+    // why the caller creates it before asking. Often absent; see above.
     if let Some(short) = ascii_path::ascii_safe(&primary) {
         candidates.push(short);
     }
-    for var in ["ProgramData", "SystemDrive"] {
+    for var in ASCII_ROOTS {
         if let Some(root) = ascii_path::env_root(var) {
-            let dir = root.join("MapleLink").join("lr");
+            let dir = root.join(ASCII_FALLBACK_DIR).join("lr");
             if ascii_path::is_ascii(&dir) && !candidates.contains(&dir) {
                 candidates.push(dir);
             }
@@ -262,8 +279,18 @@ async fn pick_lr_dir(
 /// the same candidates [`ensure_lr_files`] would have written to and returns the
 /// first that is actually there.
 pub fn find_lr_proc(app_data_dir: &std::path::Path) -> Option<PathBuf> {
-    lr_dir_candidates(app_data_dir)
-        .into_iter()
+    lr_proc_in(&lr_dir_candidates(app_data_dir))
+}
+
+/// First `LRProc.exe` that exists across `candidates`.
+///
+/// Order matters on an upgrade: a user whose profile is not ASCII may still
+/// have last version's copy sitting in the app data dir, and picking that one
+/// would put us straight back into the rundll32 failure. Candidates are already
+/// ordered ASCII-first, so the fresh copy wins.
+fn lr_proc_in(candidates: &[PathBuf]) -> Option<PathBuf> {
+    candidates
+        .iter()
         .map(|dir| dir.join("LRProc.exe"))
         .find(|exe| exe.is_file())
 }
@@ -351,19 +378,85 @@ mod tests {
         );
     }
 
+    /// The profile names actually seen in the wild: Simplified, Traditional,
+    /// mixed script, full-width punctuation, Latin-plus-Chinese.
+    const NON_ASCII_PROFILES: [&str; 5] = [
+        "小明",
+        "简体（管理員）",
+        "Dj小明",
+        "测试 user",
+        "ＭａｐｌｅＬｉｎｋ",
+    ];
+
     #[test]
     fn a_non_ascii_profile_falls_back_to_ascii_roots() {
-        let requested = std::path::Path::new(r"C:\Users\小明\AppData\Roaming\app");
-        let dirs = lr_dir_candidates(requested);
+        for profile in NON_ASCII_PROFILES {
+            let requested = PathBuf::from(format!(
+                r"C:\Users\{profile}\AppData\Roaming\com.maplelink.app"
+            ));
+            let dirs = lr_dir_candidates(&requested);
 
-        // Every usable fallback must survive LR's ANSI round-trip...
-        assert!(
-            dirs.iter().any(|p| crate::utils::ascii_path::is_ascii(p)),
-            "no ASCII candidate offered: {dirs:?}"
+            // Everything we would actually use has to survive LR's ANSI
+            // round-trip — the last entry is the log-only fallback.
+            let (log_only, usable) = dirs.split_last().unwrap();
+            assert!(
+                !usable.is_empty(),
+                "{profile}: no candidate but the original"
+            );
+            for dir in usable {
+                assert!(
+                    crate::utils::ascii_path::is_ascii(dir),
+                    "{profile}: non-ASCII candidate {}",
+                    dir.display()
+                );
+            }
+
+            // 8.3 aliases are unreliable on Chinese Windows, so an ASCII root
+            // must always be offered, not just a short name.
+            assert!(
+                usable.iter().any(|d| d.starts_with(r"C:\")
+                    && d.components().any(|c| c.as_os_str() == ASCII_FALLBACK_DIR)),
+                "{profile}: no ASCII-root fallback in {usable:?}"
+            );
+
+            // The original stays last so a total failure logs what was wanted.
+            assert_eq!(log_only, &requested.join("lr"));
+        }
+    }
+
+    #[test]
+    fn candidates_are_free_of_duplicates() {
+        // ProgramData and ALLUSERSPROFILE are the same directory on every
+        // modern Windows; offering it twice would double every retry.
+        let dirs = lr_dir_candidates(std::path::Path::new(r"C:\Users\小明\AppData\Roaming\app"));
+        let mut seen = dirs.clone();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), dirs.len(), "duplicate candidate in {dirs:?}");
+    }
+
+    #[test]
+    fn a_stale_copy_in_the_non_ascii_dir_never_wins() {
+        let root = scratch("stale");
+        let ascii = root.join("ProgramData").join("MapleLink").join("lr");
+        let non_ascii = root.join("小明").join("lr");
+        for dir in [&ascii, &non_ascii] {
+            std::fs::create_dir_all(dir).unwrap();
+            std::fs::write(dir.join("LRProc.exe"), b"stub").unwrap();
+        }
+
+        // Candidate order is ASCII-first, so an upgrade doesn't get dragged
+        // back to last version's unusable copy.
+        assert_eq!(
+            lr_proc_in(&[ascii.clone(), non_ascii.clone()]),
+            Some(ascii.join("LRProc.exe"))
         );
-
-        // ...and the original path stays last, so a failure logs what was wanted.
-        assert_eq!(dirs.last().unwrap(), &requested.join("lr"));
+        // ...but a lone old copy is still better than refusing to launch.
+        assert_eq!(
+            lr_proc_in(&[root.join("nope"), non_ascii.clone()]),
+            Some(non_ascii.join("LRProc.exe"))
+        );
+        assert_eq!(lr_proc_in(&[root.join("nope")]), None);
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/lr_service.rs
+++ b/src-tauri/src/services/lr_service.rs
@@ -134,10 +134,56 @@ async fn sync_lr_file(
     }
 }
 
-/// Extract embedded LR files to the app data directory.
+/// Every directory the LR files may live in, best first.
 ///
-/// Returns the path to `LRProc.exe`. All LR files are placed in
-/// `<app_data_dir>/lr/` so they are co-located as required by LRProc.
+/// **LR cannot be given a non-ASCII path.** It bridges 32/64-bit by reading its
+/// own DLL path back with `GetModuleFileNameA` and formatting it into
+/// `rundll32.exe "%hs",#1` — a narrow string, converted under the code page LR
+/// has itself just spoofed to 950. A profile name outside that code page (a
+/// Chinese account name, Simplified or Traditional; a full-width symbol) comes
+/// back mangled, and rundll32 pops "the specified module could not be found".
+/// The conversion lives inside LR's shipped binaries, so the only lever we have
+/// is where we put the files.
+///
+/// So: `<app_data_dir>/lr` when the profile name is ASCII (nearly everyone,
+/// unchanged); its 8.3 short form next, which names the very same directory and
+/// so needs no migration; and finally two roots that are ASCII on every Windows
+/// install, for volumes with 8.3 name creation switched off.
+///
+/// The plain long path is always last so a failure is a failed launch with the
+/// real path in the log, not an empty candidate list.
+pub fn lr_dir_candidates(app_data_dir: &std::path::Path) -> Vec<PathBuf> {
+    use crate::utils::ascii_path;
+
+    let primary = app_data_dir.join("lr");
+    if ascii_path::is_ascii(&primary) {
+        return vec![primary];
+    }
+
+    let mut candidates = Vec::new();
+    // Same directory, ASCII alias — only exists once `primary` does, which is
+    // why the caller creates it before asking.
+    if let Some(short) = ascii_path::ascii_safe(&primary) {
+        candidates.push(short);
+    }
+    for var in ["ProgramData", "SystemDrive"] {
+        if let Some(root) = ascii_path::env_root(var) {
+            let dir = root.join("MapleLink").join("lr");
+            if ascii_path::is_ascii(&dir) && !candidates.contains(&dir) {
+                candidates.push(dir);
+            }
+        }
+    }
+    candidates.push(primary);
+    candidates
+}
+
+/// Extract embedded LR files to an ASCII-safe directory.
+///
+/// Returns the path to `LRProc.exe`. All LR files are placed in one directory
+/// so they are co-located as required by LRProc — normally `<app_data_dir>/lr/`,
+/// but see [`lr_dir_candidates`] for why a non-ASCII user profile forces us
+/// somewhere else.
 ///
 /// Every file is re-extracted on each call (see [`sync_lr_file`]) rather than
 /// compared first, so the shipped binaries always win over whatever is on disk.
@@ -152,19 +198,74 @@ pub async fn ensure_lr_files(app_handle: &tauri::AppHandle) -> Result<PathBuf, P
             reason: format!("Failed to resolve app data directory: {e}"),
         })?;
 
-    let lr_dir = app_data_dir.join("lr");
-    tokio::fs::create_dir_all(&lr_dir)
-        .await
-        .map_err(|e| ProcessError::SpawnFailed {
-            path: lr_dir.display().to_string(),
-            reason: format!("Failed to create LR directory: {e}"),
-        })?;
+    // Create the normal location first: a short name can only be read back off
+    // a directory that exists, and this is where the files go anyway when the
+    // path is already ASCII.
+    let primary = app_data_dir.join("lr");
+    let primary_err = tokio::fs::create_dir_all(&primary).await.err();
+
+    let candidates = lr_dir_candidates(&app_data_dir);
+    let lr_dir = pick_lr_dir(&candidates, primary_err).await?;
+
+    if lr_dir != primary {
+        tracing::info!(
+            requested = %primary.display(),
+            using = %lr_dir.display(),
+            "user profile is not ASCII — extracting LR somewhere Locale Remulator can name"
+        );
+    }
 
     for &(filename, data) in EMBEDDED_LR {
         sync_lr_file(&lr_dir, filename, data).await?;
     }
 
     Ok(lr_dir.join("LRProc.exe"))
+}
+
+/// First candidate we can actually create, or a spawn error naming them all.
+///
+/// `primary_err` is the failure from creating the first candidate, if any — it
+/// is the most useful thing to report when nothing works.
+async fn pick_lr_dir(
+    candidates: &[PathBuf],
+    primary_err: Option<std::io::Error>,
+) -> Result<PathBuf, ProcessError> {
+    let mut last_err = primary_err;
+
+    for dir in candidates {
+        match tokio::fs::create_dir_all(dir).await {
+            Ok(()) => return Ok(dir.clone()),
+            Err(e) => {
+                tracing::warn!(dir = %dir.display(), "could not create LR directory: {e}");
+                last_err = Some(e);
+            }
+        }
+    }
+
+    let tried = candidates
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(ProcessError::SpawnFailed {
+        path: tried,
+        reason: match last_err {
+            Some(e) => format!("Failed to create LR directory: {e}"),
+            None => "Failed to create LR directory".to_string(),
+        },
+    })
+}
+
+/// Locate an already-extracted `LRProc.exe` without an `AppHandle`.
+///
+/// Used by the headless web-launch path, which runs before Tauri starts. Walks
+/// the same candidates [`ensure_lr_files`] would have written to and returns the
+/// first that is actually there.
+pub fn find_lr_proc(app_data_dir: &std::path::Path) -> Option<PathBuf> {
+    lr_dir_candidates(app_data_dir)
+        .into_iter()
+        .map(|dir| dir.join("LRProc.exe"))
+        .find(|exe| exe.is_file())
 }
 
 /// Check if the system locale is Traditional Chinese.
@@ -239,6 +340,55 @@ mod tests {
         let out = sync_lr_file(&dir, "f.bin", b"BBBB").await.unwrap();
         assert_eq!(out, SyncOutcome::Written);
         assert_eq!(std::fs::read(dir.join("f.bin")).unwrap(), b"BBBB");
+    }
+
+    #[test]
+    fn an_ascii_profile_keeps_the_files_in_app_data() {
+        let dirs = lr_dir_candidates(std::path::Path::new(r"C:\Users\bob\AppData\Roaming\app"));
+        assert_eq!(
+            dirs,
+            vec![PathBuf::from(r"C:\Users\bob\AppData\Roaming\app\lr")]
+        );
+    }
+
+    #[test]
+    fn a_non_ascii_profile_falls_back_to_ascii_roots() {
+        let requested = std::path::Path::new(r"C:\Users\小明\AppData\Roaming\app");
+        let dirs = lr_dir_candidates(requested);
+
+        // Every usable fallback must survive LR's ANSI round-trip...
+        assert!(
+            dirs.iter().any(|p| crate::utils::ascii_path::is_ascii(p)),
+            "no ASCII candidate offered: {dirs:?}"
+        );
+
+        // ...and the original path stays last, so a failure logs what was wanted.
+        assert_eq!(dirs.last().unwrap(), &requested.join("lr"));
+    }
+
+    #[tokio::test]
+    async fn pick_lr_dir_skips_candidates_it_cannot_create() {
+        let good = scratch("pick").join("lr");
+        // A path under a *file* can never be created.
+        let blocked = scratch("pick_blocked").join("wall");
+        std::fs::write(&blocked, b"x").unwrap();
+
+        let chosen = pick_lr_dir(&[blocked.join("lr"), good.clone()], None)
+            .await
+            .unwrap();
+        assert_eq!(chosen, good);
+        assert!(good.is_dir());
+    }
+
+    #[tokio::test]
+    async fn pick_lr_dir_reports_every_path_it_tried() {
+        let blocked = scratch("pick_none").join("wall");
+        std::fs::write(&blocked, b"x").unwrap();
+        let err = pick_lr_dir(&[blocked.join("a"), blocked.join("b")], None)
+            .await
+            .unwrap_err();
+        let ProcessError::SpawnFailed { path, .. } = err;
+        assert!(path.contains("a") && path.contains("b"), "got {path}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/web_launch.rs
+++ b/src-tauri/src/services/web_launch.rs
@@ -56,18 +56,11 @@ pub fn register() -> std::io::Result<()> {
             "game path not set — set the game path first",
         )
     })?;
-    // `cmd.exe` reads a .bat byte-by-byte under the console's OEM code page, not
-    // UTF-8, so a per-user install under a non-ASCII profile name would reach
-    // `start` mangled. Write the 8.3 alias instead — same exe, pure ASCII.
+    // Prefer the 8.3 alias: a pure-ASCII path is immune to however cmd.exe
+    // decodes the file. On a Chinese Windows there often isn't one, so the
+    // encoding below has to carry it instead.
     let exe_path = std::env::current_exe()?;
     let exe = crate::utils::ascii_path::ascii_safe_str(&exe_path);
-    if !exe.is_ascii() {
-        tracing::warn!(
-            path = %exe,
-            "MapleLink is installed under a non-ASCII path with no 8.3 alias; \
-             the web-launch helper .bat may not find it"
-        );
-    }
 
     // beanfun passes: <server> <port> BeanFun <account> <otp> → %4/%5. We echo
     // those (console, for scripts) and forward everything to MapleLink, tagged
@@ -84,7 +77,7 @@ pub fn register() -> std::io::Result<()> {
          echo MapleLink is launching the game...\r\n\
          pause>nul\r\n"
     );
-    std::fs::write(&bat, script)?;
+    std::fs::write(&bat, helper_bat_bytes(&script)?)?;
     let bat_str = bat.to_string_lossy().into_owned();
 
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
@@ -99,6 +92,28 @@ pub fn register() -> std::io::Result<()> {
     key.set_value(PATH_VALUE, &bat_str)?;
     tracing::info!("web-launch interception registered: {bat_str}");
     Ok(())
+}
+
+/// Encode the helper script the way `cmd.exe` will read it back.
+///
+/// A `.bat` is not a UTF-8 file: cmd decodes it byte-by-byte in the console's
+/// code page, so writing `start "" "C:\Users\小明\...\maplelink.exe"` as UTF-8
+/// hands `start` a mangled path and the web launch quietly does nothing. Almost
+/// every script here is pure ASCII and encodes identically either way; this only
+/// bites when MapleLink is installed per-user under a non-ASCII profile name and
+/// the volume has no 8.3 alias to fall back on.
+///
+/// Refuses rather than writes a script that cannot work, so the caller reports a
+/// failed registration instead of a helper that silently never launches.
+#[cfg(target_os = "windows")]
+fn helper_bat_bytes(script: &str) -> std::io::Result<Vec<u8>> {
+    crate::utils::ascii_path::oem_bytes(script).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "MapleLink's install path cannot be written to a .bat on this PC; \
+             reinstall it to a folder with an English name",
+        )
+    })
 }
 
 /// Point the Gamania key straight at MapleLink, with no console helper in

--- a/src-tauri/src/services/web_launch.rs
+++ b/src-tauri/src/services/web_launch.rs
@@ -56,7 +56,18 @@ pub fn register() -> std::io::Result<()> {
             "game path not set — set the game path first",
         )
     })?;
-    let exe = std::env::current_exe()?.to_string_lossy().into_owned();
+    // `cmd.exe` reads a .bat byte-by-byte under the console's OEM code page, not
+    // UTF-8, so a per-user install under a non-ASCII profile name would reach
+    // `start` mangled. Write the 8.3 alias instead — same exe, pure ASCII.
+    let exe_path = std::env::current_exe()?;
+    let exe = crate::utils::ascii_path::ascii_safe_str(&exe_path);
+    if !exe.is_ascii() {
+        tracing::warn!(
+            path = %exe,
+            "MapleLink is installed under a non-ASCII path with no 8.3 alias; \
+             the web-launch helper .bat may not find it"
+        );
+    }
 
     // beanfun passes: <server> <port> BeanFun <account> <otp> → %4/%5. We echo
     // those (console, for scripts) and forward everything to MapleLink, tagged
@@ -751,11 +762,10 @@ fn launch_game(game_path: &str, raw_args: &[String]) -> bool {
 /// app data dir once any normal launch has run).
 fn lr_proc_path() -> Option<std::path::PathBuf> {
     let appdata = std::env::var("APPDATA").ok()?;
-    let p = std::path::Path::new(&appdata)
-        .join("com.maplelink.app")
-        .join("lr")
-        .join("LRProc.exe");
-    p.exists().then_some(p)
+    let app_data_dir = std::path::Path::new(&appdata).join("com.maplelink.app");
+    // Not always `<app_data>/lr` — a non-ASCII profile name pushes the files
+    // elsewhere. See `lr_service::lr_dir_candidates`.
+    crate::services::lr_service::find_lr_proc(&app_data_dir)
 }
 
 /// Spawn `program` with `args`, cwd = the game folder. Returns whether spawn

--- a/src-tauri/src/utils/ascii_path.rs
+++ b/src-tauri/src/utils/ascii_path.rs
@@ -1,0 +1,166 @@
+//! Making paths safe to hand to code that still speaks ANSI.
+//!
+//! A few things MapleLink drives are not Unicode-clean:
+//!
+//! * Locale Remulator bridges 32/64-bit by reading its own DLL path back with
+//!   `GetModuleFileNameA` and formatting it into `rundll32.exe "%hs",#1` — a
+//!   narrow string, converted under the code page LR has *already* spoofed to
+//!   950. A profile name outside that code page comes back mangled and
+//!   rundll32 reports "the specified module could not be found".
+//! * `cmd.exe` reads `.bat` files byte-by-byte under the console's OEM code
+//!   page, not UTF-8.
+//!
+//! Neither can be fixed where it happens, so the paths we hand them have to be
+//! ASCII. Windows already keeps an ASCII alias for most files — the 8.3 short
+//! name — so [`ascii_safe`] uses that when the real path isn't ASCII.
+
+use std::path::{Path, PathBuf};
+
+/// Whether every character in `path` is ASCII, i.e. it survives a round-trip
+/// through any Windows code page unchanged.
+pub fn is_ascii(path: &Path) -> bool {
+    path.as_os_str().to_string_lossy().is_ascii()
+}
+
+/// The Windows 8.3 short form of `path` (`C:\Users\ABCDEF~1\...`).
+///
+/// Returns `None` when the path doesn't exist or the volume has 8.3 name
+/// creation turned off — in which case Windows hands back the long name
+/// unchanged and there is no ASCII alias to be had.
+#[cfg(target_os = "windows")]
+pub fn short_path(path: &Path) -> Option<PathBuf> {
+    use std::ffi::{OsStr, OsString};
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+    let wide: Vec<u16> = OsStr::new(path)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // First call sizes the buffer (result includes the NUL), second fills it.
+    let needed = unsafe { GetShortPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0) };
+    if needed == 0 {
+        return None;
+    }
+    let mut buf = vec![0u16; needed as usize];
+    let written = unsafe { GetShortPathNameW(wide.as_ptr(), buf.as_mut_ptr(), needed) };
+    if written == 0 || written >= needed {
+        return None;
+    }
+
+    Some(PathBuf::from(OsString::from_wide(&buf[..written as usize])))
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn short_path(_path: &Path) -> Option<PathBuf> {
+    None
+}
+
+/// `path` itself when it is already ASCII, otherwise its 8.3 short form if that
+/// one is. `None` means this path cannot be expressed in ASCII at all and the
+/// caller needs a different location entirely.
+///
+/// The short form names the *same* directory entry, so nothing has to be copied
+/// or migrated — files written through the long path are visible through it.
+pub fn ascii_safe(path: &Path) -> Option<PathBuf> {
+    if is_ascii(path) {
+        return Some(path.to_path_buf());
+    }
+    short_path(path).filter(|p| is_ascii(p))
+}
+
+/// [`ascii_safe`] as a string, falling back to the original path when there is
+/// no ASCII alias. For callers that would rather try and fail loudly than not
+/// try at all.
+pub fn ascii_safe_str(path: &Path) -> String {
+    ascii_safe(path)
+        .unwrap_or_else(|| path.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// An environment-variable directory root, normalised for [`Path::join`].
+///
+/// `%SystemDrive%` is `C:` with no separator; joining onto that yields the
+/// drive-relative `C:MapleLink`, not `C:\MapleLink`.
+pub fn env_root(var: &str) -> Option<PathBuf> {
+    let value = std::env::var(var).ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(if value.ends_with(':') {
+        format!("{value}\\")
+    } else {
+        value.to_string()
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_ascii_paths_are_returned_unchanged() {
+        let p = Path::new(r"C:\Nexon\MapleStory");
+        assert!(is_ascii(p));
+        assert_eq!(ascii_safe(p).as_deref(), Some(p));
+    }
+
+    #[test]
+    fn non_ascii_paths_are_not_ascii() {
+        assert!(!is_ascii(Path::new(r"C:\Users\小明\AppData")));
+    }
+
+    #[test]
+    fn a_missing_non_ascii_path_has_no_ascii_alias() {
+        // Nothing to shorten — Windows can only produce an 8.3 name for a file
+        // that exists, so this must not silently return the mangled long path.
+        let p = Path::new(r"C:\maplelink-does-not-exist-小明\lr");
+        assert_eq!(ascii_safe(p), None);
+        assert_eq!(ascii_safe_str(p), p.to_string_lossy());
+    }
+
+    #[test]
+    fn the_ascii_alias_names_the_same_directory() {
+        let base = std::env::temp_dir().join("maplelink_ascii_path_測試小明");
+        let dir = base.join("lr");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(!is_ascii(&dir));
+
+        match ascii_safe(&dir) {
+            Some(alias) => {
+                assert!(is_ascii(&alias), "alias must be ASCII: {}", alias.display());
+                // Nothing is copied — a file written through the long path is
+                // readable through the alias.
+                std::fs::write(dir.join("probe.bin"), b"ok").unwrap();
+                assert_eq!(std::fs::read(alias.join("probe.bin")).unwrap(), b"ok");
+            }
+            // 8.3 name creation is off on this volume; `lr_dir_candidates` then
+            // falls back to an ASCII root instead.
+            None => eprintln!("no 8.3 name on {}; skipped", base.display()),
+        }
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn env_root_gives_a_joinable_drive_root() {
+        std::env::set_var("MAPLELINK_TEST_ROOT", "C:");
+        assert_eq!(
+            env_root("MAPLELINK_TEST_ROOT").unwrap().join("MapleLink"),
+            PathBuf::from(r"C:\MapleLink"),
+        );
+        std::env::remove_var("MAPLELINK_TEST_ROOT");
+    }
+
+    #[test]
+    fn env_root_ignores_unset_and_blank_variables() {
+        assert_eq!(env_root("MAPLELINK_TEST_UNSET_VAR"), None);
+        std::env::set_var("MAPLELINK_TEST_BLANK", "   ");
+        assert_eq!(env_root("MAPLELINK_TEST_BLANK"), None);
+        std::env::remove_var("MAPLELINK_TEST_BLANK");
+    }
+}

--- a/src-tauri/src/utils/ascii_path.rs
+++ b/src-tauri/src/utils/ascii_path.rs
@@ -11,8 +11,17 @@
 //!   page, not UTF-8.
 //!
 //! Neither can be fixed where it happens, so the paths we hand them have to be
-//! ASCII. Windows already keeps an ASCII alias for most files — the 8.3 short
-//! name — so [`ascii_safe`] uses that when the real path isn't ASCII.
+//! ASCII. Windows keeps an ASCII alias for many files — the 8.3 short name — so
+//! [`ascii_safe`] uses that when the real path isn't ASCII.
+//!
+//! Do not lean on it, though. Windows only bothers generating an 8.3 alias for a
+//! name it cannot already express in the OEM code page, and on a Chinese Windows
+//! (OEM 936/950) a Chinese folder name *is* expressible: `GetShortPathNameW`
+//! then hands the name straight back. `C:\Users\小明` shortens on an English
+//! install and does not on a Chinese one — which is to say, not on the machines
+//! that need it. Callers need a second way out: somewhere else to put the file
+//! (see `lr_service::lr_dir_candidates`) or, for text a narrow reader will
+//! decode anyway, writing it in that reader's code page ([`oem_bytes`]).
 
 use std::path::{Path, PathBuf};
 
@@ -81,6 +90,83 @@ pub fn ascii_safe_str(path: &Path) -> String {
         .into_owned()
 }
 
+/// Encode `text` in the OEM code page — the encoding `cmd.exe` assumes when it
+/// reads a `.bat`, and the one a console inherits by default.
+///
+/// Writing a batch file as UTF-8 mangles every non-ASCII byte in it; a game
+/// folder or an install path under a Chinese profile name then never reaches
+/// `start`. Pure-ASCII text encodes identically either way, so this is a no-op
+/// for almost every user.
+///
+/// Returns `None` when the text cannot be represented in that code page at all,
+/// which is the caller's cue that no batch file will carry it.
+#[cfg(target_os = "windows")]
+pub fn oem_bytes(text: &str) -> Option<Vec<u8>> {
+    use windows_sys::Win32::Globalization::{GetOEMCP, WideCharToMultiByte};
+
+    if text.is_ascii() {
+        return Some(text.as_bytes().to_vec());
+    }
+
+    let wide: Vec<u16> = text.encode_utf16().collect();
+    let code_page = unsafe { GetOEMCP() };
+
+    // A UTF code page rejects the substitution-character arguments below, and
+    // needs none of them — everything round-trips.
+    const CP_UTF7: u32 = 65000;
+    const CP_UTF8: u32 = 65001;
+    let unicode_cp = matches!(code_page, CP_UTF7 | CP_UTF8);
+
+    let len = unsafe {
+        WideCharToMultiByte(
+            code_page,
+            0,
+            wide.as_ptr(),
+            wide.len() as i32,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null(),
+            std::ptr::null_mut(),
+        )
+    };
+    if len <= 0 {
+        return None;
+    }
+
+    let mut buf = vec![0u8; len as usize];
+    // Ask whether anything had to be replaced by a substitute character: a
+    // lossy encoding is a path that will not resolve, so report it as failure
+    // rather than write a file that silently points nowhere.
+    let mut used_default: i32 = 0;
+    let written = unsafe {
+        WideCharToMultiByte(
+            code_page,
+            0,
+            wide.as_ptr(),
+            wide.len() as i32,
+            buf.as_mut_ptr(),
+            len,
+            std::ptr::null(),
+            if unicode_cp {
+                std::ptr::null_mut()
+            } else {
+                &mut used_default
+            },
+        )
+    };
+    if written <= 0 || used_default != 0 {
+        return None;
+    }
+
+    buf.truncate(written as usize);
+    Some(buf)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn oem_bytes(text: &str) -> Option<Vec<u8>> {
+    Some(text.as_bytes().to_vec())
+}
+
 /// An environment-variable directory root, normalised for [`Path::join`].
 ///
 /// `%SystemDrive%` is `C:` with no separator; joining onto that yields the
@@ -144,6 +230,29 @@ mod tests {
         }
 
         std::fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn ascii_text_encodes_byte_for_byte() {
+        // Every code page agrees on ASCII, so the common case must be untouched.
+        let script = "@echo off\r\nstart \"\" \"C:\\Program Files\\MapleLink\\maplelink.exe\"\r\n";
+        assert_eq!(oem_bytes(script).unwrap(), script.as_bytes());
+    }
+
+    #[test]
+    fn a_non_ascii_script_is_encoded_or_refused_never_mangled() {
+        // What `register` writes when MapleLink sits under a Chinese profile.
+        let script = "start \"\" \"C:\\Users\\简体（管理員）\\maplelink.exe\" --web-launch %*\r\n";
+        // Latin Windows (OEM 437/850) refuses outright, so the caller reports a
+        // failure instead of writing a dud helper. Chinese Windows (OEM 936/950)
+        // encodes it, and then cmd must read the ASCII scaffolding as written.
+        if let Some(bytes) = oem_bytes(script) {
+            assert!(bytes.starts_with(b"start \"\" \"C:\\Users\\"));
+            assert!(bytes.ends_with(b"\\maplelink.exe\" --web-launch %*\r\n"));
+            // A substituted character would be a path that resolves to nothing;
+            // the input has no '?' of its own.
+            assert!(!bytes.contains(&b'?'), "lossy encoding slipped through");
+        }
     }
 
     #[test]

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Shared helper functions (crypto, formatting, etc.).
 
+pub mod ascii_path;
 pub mod clipboard;
 pub mod crypto;
 pub mod dpapi;

--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -54,7 +54,10 @@
     "windows": {
       "nsis": {
         "installMode": "both",
-        "displayLanguageSelector": false
+        "displayLanguageSelector": false,
+        // Removes the ASCII fallback dir the LR extraction may create outside
+        // $INSTDIR (non-ASCII Windows profile names). See the file's header.
+        "installerHooks": "../installer/hooks.nsh"
       }
     }
   }


### PR DESCRIPTION
## What

- Extract Locale Remulator to an ASCII directory: `<app_data>/lr` when the path is ASCII, else its 8.3 alias, else `%ProgramData%\MapleLink\lr` / `%SystemDrive%\MapleLink\lr`.
- Write the web-launch helper `.bat` in the OEM code page; refuse to register instead of writing one that cannot work.
- NSIS `POSTUNINSTALL` hook removes the fallback dir (only our `lr` folder, plus the parent if it is then empty).
- Escape single quotes in the café-mode WebView2 wipe script.

## Why

LR bridges 32/64-bit by reading its own DLL path back with `GetModuleFileNameA` and formatting it into `rundll32.exe "%hs",#1` — a narrow string, converted under the code page LR has itself just spoofed to 950. A profile name outside that code page comes back mangled and rundll32 reports "the specified module could not be found", so the game never starts.

The 8.3 alias alone is not enough: Windows only generates one for a name it cannot already express in the OEM code page, so on a Chinese Windows (OEM 936/950) a Chinese folder name gets no alias at all. The ASCII-root fallback is what carries those users.

`cmd.exe` reads a `.bat` in the console code page, not UTF-8, so the helper had the same problem. A profile name with an apostrophe also made the café wipe script a parse error, so none of the cleanup ran.

## How to test

- 8.3 alias points at the same directory (`ascii_path` tests) and candidate order survives an upgrade (`lr_service` tests).
- NSIS hook: confirmed inserted (`!warning` in `NSIS_HOOK_POSTUNINSTALL`) and run standalone — it removed `%ProgramData%\MapleLink\lr` and its empty parent, removed `C:\MapleLink\lr`, and left a non-empty `C:\MapleLink` and its other files alone.
- Not covered: an actual game launch under a Chinese profile name — no such account available here.

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes
- [x] Tested locally with `cargo tauri dev` (ran `tauri build`; the fallback path needs a non-ASCII profile)
- [x] No breaking changes to existing features