### PR TITLE
harden(http): verify certificates, and bound every third-party read

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,8 +452,27 @@ pub fn run() {
             let announcement_dismissed = !config.announcement_dismissed_id.is_empty();
             let update_channel = config.update_channel.clone();
             let github_hosts_enabled = config.github_hosts;
+            // Certificates are verified here. This client carries the update —
+            // the release listing, and the executable that replaces the running
+            // one, which is then written over it unsigned. Accepting any
+            // certificate meant anything on the path could answer in GitHub's
+            // place, and for the users the mirrors and the hosts override exist
+            // for, "anything on the path" is what those features are routing
+            // around.
+            //
+            // The exception was not a fix for anything: it dates from the
+            // initial commit, and the accelerator problem it looked like it
+            // might belong to is a different one — accelerators match by process
+            // name, which is why #37 renames the exe. Checked on a machine
+            // running AK and LeiGod together: GitHub still served its own
+            // Sectigo certificate and validated. An accelerator that does
+            // intercept installs its root in the Windows store, which native-tls
+            // reads, so those users validate too — against what their own
+            // machine already trusts.
+            //
+            // beanfun's own clients keep their exception. Nothing here talks to
+            // beanfun, and its certificates have not been checked the same way.
             let http_client = reqwest::Client::builder()
-                .danger_accept_invalid_certs(true)
                 .build()
                 .expect("failed to build HTTP client");
             let update_client = http_client.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -470,9 +470,14 @@ pub fn run() {
             // reads, so those users validate too — against what their own
             // machine already trusts.
             //
-            // beanfun's own clients keep their exception. Nothing here talks to
-            // beanfun, and its certificates have not been checked the same way.
+            // A connect timeout, and deliberately not a total one: this client
+            // carries the 12 MB update, and reqwest's `timeout` covers the body
+            // too — which is how a 300-second cap came to cut off mainland users
+            // who were downloading perfectly well, just slowly. Opening a
+            // connection is the part that should be quick; the download names
+            // its own deadlines, per chunk.
             let http_client = reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(10))
                 .build()
                 .expect("failed to build HTTP client");
             let update_client = http_client.clone();

--- a/src-tauri/src/models/session_state.rs
+++ b/src-tauri/src/models/session_state.rs
@@ -92,9 +92,20 @@ impl SessionState {
         let http_client = reqwest::Client::builder()
             .cookie_provider(cookie_jar.clone())
             .default_headers(default_headers)
+            // Certificates are verified. This connection carries the account
+            // name, the password and the one-time password, so an unverified
+            // one means anybody on the path can read them — a worse outcome
+            // than the update path, where the worst case is a substituted
+            // executable.
+            //
+            // The exception this replaces dates from the initial commit and was
+            // never a fix for anything. Checked on machines running AK, UU and
+            // LeiGod: every beanfun host served its own Amazon-issued
+            // certificate and validated. An accelerator that does intercept
+            // installs its root in the Windows store, which native-tls reads,
+            // so those users validate too.
             .http1_only()
             .timeout(Duration::from_secs(30))
-            .danger_accept_invalid_certs(true)
             .build()
             .expect("failed to build HTTP client");
 

--- a/src-tauri/src/services/beanfun_service.rs
+++ b/src-tauri/src/services/beanfun_service.rs
@@ -1213,7 +1213,6 @@ async fn tw_get_session_key(
         .redirect(reqwest::redirect::Policy::none())
         .http1_only()
         .timeout(std::time::Duration::from_secs(30))
-        .danger_accept_invalid_certs(true)
         .build()
         .map_err(|e| map_reqwest_error(url, e))?;
 
@@ -1711,9 +1710,12 @@ async fn tw_send_login_flow(
         }
     }
 
+    // The only client in the app that named no deadline at all, and it posts
+    // to beanfun mid-login: a host that accepts the connection and then says
+    // nothing would have held the login open indefinitely.
     let no_redirect_client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
-        .danger_accept_invalid_certs(true)
+        .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| parse_error_str(&format!("failed to build no-redirect client: {e}")))?;
 

--- a/src-tauri/src/services/game_env_service.rs
+++ b/src-tauri/src/services/game_env_service.rs
@@ -48,14 +48,20 @@ pub async fn detect_game_path(state: &AppState) -> Result<Option<String>, ErrorD
             "https://{host}.beanfun.com/beanfun_block/generic_handlers/get_service_ini.ashx"
         );
 
+        // The shared client sets no deadline of its own, and this is the only
+        // request on it that never named one. The file is a few KB of ini, so
+        // the bound below is generous and still finite.
         if let Ok(ini_text) = state
             .http_client
             .get(&ini_url)
             .header("User-Agent", WEBVIEW_USER_AGENT)
+            .timeout(std::time::Duration::from_secs(15))
             .send()
             .await
         {
-            if let Ok(body) = ini_text.text().await {
+            if let Some(body) =
+                crate::services::http_util::read_capped_text(ini_text, 4 * 1024 * 1024).await
+            {
                 let game_code = "610074_T9";
                 let dir_reg = extract_ini_value(&body, game_code, "dir_reg");
                 let dir_value_name = extract_ini_value(&body, game_code, "dir_value_name");

--- a/src-tauri/src/services/ggm_hotfix.rs
+++ b/src-tauri/src/services/ggm_hotfix.rs
@@ -124,7 +124,10 @@ async fn fetch(client: &reqwest::Client) -> Option<(String, String)> {
         if !response.status().is_success() {
             continue;
         }
-        let Ok(body) = response.text().await else {
+        // The real file is under 200 bytes, and every source is a mirror of
+        // one repository — anything substantial is answering something else.
+        let Some(body) = crate::services::http_util::read_capped_text(response, 64 * 1024).await
+        else {
             continue;
         };
         let Some(pair) = parse(&body) else {

--- a/src-tauri/src/services/github_hosts.rs
+++ b/src-tauri/src/services/github_hosts.rs
@@ -105,6 +105,11 @@ const FETCH_TIMEOUT: Duration = Duration::from_secs(6);
 /// answers with something else.
 const MAX_LIST_BYTES: u64 = 4 * 1024 * 1024;
 
+/// How much of a DoH answer is worth reading. A handful of A records is a few
+/// hundred bytes; two of the three resolvers are domestic ones this feature
+/// exists precisely because it cannot take on trust.
+const MAX_DOH_BYTES: u64 = 64 * 1024;
+
 /// A domain → IPs mapping parsed out of a hosts file.
 pub type HostsMap = HashMap<String, Vec<IpAddr>>;
 
@@ -226,7 +231,11 @@ async fn doh_lookup(client: &reqwest::Client, endpoint: &str, host: &str) -> Vec
     if !response.status().is_success() {
         return Vec::new();
     }
-    let Ok(json) = response.json::<serde_json::Value>().await else {
+    let Some(body) = crate::services::http_util::read_capped_text(response, MAX_DOH_BYTES).await
+    else {
+        return Vec::new();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) else {
         return Vec::new();
     };
 

--- a/src-tauri/src/services/github_hosts.rs
+++ b/src-tauri/src/services/github_hosts.rs
@@ -17,9 +17,9 @@
 //! - addresses that arrive over DNS rather than from the curated list must sit
 //!   inside GitHub's own address blocks, which is also what makes a poisoned
 //!   answer detectable;
-//! - the client built here validates certificates, unlike the app-wide one, so
-//!   a wrong or hostile IP fails the handshake and we fall back to the mirrors
-//!   rather than downloading an exe from it.
+//! - certificates are validated, so an override says which address to dial and
+//!   never who may answer: a wrong or hostile IP fails the handshake and we fall
+//!   back to the mirrors rather than downloading an exe from it.
 //!
 //! Where the list comes from matters as much as what's in it: the users who
 //! need it are exactly the ones who cannot fetch it from GitHub. So several

--- a/src-tauri/src/services/github_hosts.rs
+++ b/src-tauri/src/services/github_hosts.rs
@@ -100,6 +100,11 @@ const ALLOWED_SUFFIXES: &[&str] = &["github.com", "githubusercontent.com", "gith
 /// many.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(6);
 
+/// How much of a hosts list is worth reading. The real one is a few hundred KB;
+/// this leaves it room to grow several times over and still stops a mirror that
+/// answers with something else.
+const MAX_LIST_BYTES: u64 = 4 * 1024 * 1024;
+
 /// A domain → IPs mapping parsed out of a hosts file.
 pub type HostsMap = HashMap<String, Vec<IpAddr>>;
 
@@ -275,7 +280,9 @@ async fn fetch(client: &reqwest::Client, url: &str) -> Option<String> {
     if !response.status().is_success() {
         return None;
     }
-    response.text().await.ok()
+    // Every source here is replaceable, so one answering with something
+    // enormous is dropped rather than parsed.
+    crate::services::http_util::read_capped_text(response, MAX_LIST_BYTES).await
 }
 
 /// Download the list.

--- a/src-tauri/src/services/github_hosts.rs
+++ b/src-tauri/src/services/github_hosts.rs
@@ -170,7 +170,11 @@ pub fn build_client(map: &HostsMap) -> Option<reqwest::Client> {
         return None;
     }
 
-    let mut builder = reqwest::Client::builder();
+    // Certificates are verified, so an override says which address to dial and
+    // never who may answer. A connect timeout matters more here than elsewhere:
+    // an override can name an address that has stopped answering, and each of
+    // those costs a full connect before the mirrors get a turn.
+    let mut builder = reqwest::Client::builder().connect_timeout(Duration::from_secs(10));
     for (host, ips) in map {
         // Port 0 means "the conventional port for the scheme", so one override
         // covers both https and the plain-http redirects GitHub occasionally

--- a/src-tauri/src/services/http_util.rs
+++ b/src-tauri/src/services/http_util.rs
@@ -1,0 +1,94 @@
+//! Bounded reads for bodies that come from somewhere we do not control.
+//!
+//! Every GitHub request in this app can be answered by a proxy mirror instead —
+//! that is what the mirrors are for — so "the server would not do that" is not
+//! an assumption available here. A body is read up to a stated limit and no
+//! further.
+
+use futures_util::StreamExt;
+
+/// Read a response body, stopping at `limit` rather than at whatever the sender
+/// decides to send.
+///
+/// The declared length only sizes the buffer, and only as far as `limit`: it is
+/// the sender's claim about itself, and a claim of 999999999999 asks the
+/// allocator for 931 GB, which fails, which aborts the process.
+pub async fn read_capped(response: reqwest::Response, limit: u64) -> Result<Vec<u8>, String> {
+    let reserve = response.content_length().unwrap_or(0).min(limit);
+    let mut body: Vec<u8> = Vec::with_capacity(reserve as usize);
+
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("{e}"))?;
+        if body.len() as u64 + chunk.len() as u64 > limit {
+            return Err(format!("the body ran past {limit} bytes"));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// [`read_capped`], decoded as UTF-8. `None` covers an oversized body and one
+/// that is not text alike — every caller treats them the same way.
+pub async fn read_capped_text(response: reqwest::Response, limit: u64) -> Option<String> {
+    String::from_utf8(read_capped(response, limit).await.ok()?).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+
+    /// Serve one response and hand back its URL. A real socket rather than a
+    /// constructed `Response`, so `Content-Length` reaches the code under test
+    /// the way a mirror would actually send it.
+    fn serve_once(headers: &str, body: &'static [u8]) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let headers = headers.to_string();
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let _ = sock.read(&mut [0u8; 1024]);
+            let _ = write!(sock, "HTTP/1.1 200 OK\r\n{headers}\r\n\r\n");
+            let _ = sock.write_all(body);
+        });
+        format!("http://{addr}/")
+    }
+
+    #[tokio::test]
+    async fn a_body_under_the_limit_is_read_whole() {
+        let url = serve_once("Content-Length: 5", b"hello");
+        let response = reqwest::get(&url).await.unwrap();
+        assert_eq!(read_capped(response, 1024).await.unwrap(), b"hello");
+    }
+
+    /// Refused rather than truncated: a half-read update manifest is not
+    /// something a caller should have to notice.
+    #[tokio::test]
+    async fn a_body_over_the_limit_is_refused() {
+        let url = serve_once("Content-Length: 5", b"hello");
+        let response = reqwest::get(&url).await.unwrap();
+        assert!(read_capped(response, 2).await.is_err());
+    }
+
+    /// The reservation follows the limit, not the claim. Without the `min` this
+    /// asks for 931 GB and the process dies before the assert runs.
+    #[tokio::test]
+    async fn an_absurd_content_length_does_not_size_the_buffer() {
+        let url = serve_once("Content-Length: 999999999999", b"hi");
+        let response = reqwest::get(&url).await.unwrap();
+        // The connection closes early, so the read fails — the point is that we
+        // are still here to see it fail.
+        let _ = read_capped(response, 64 * 1024).await;
+    }
+
+    #[tokio::test]
+    async fn text_comes_back_decoded() {
+        let url = serve_once("Content-Length: 5", b"hosts");
+        let response = reqwest::get(&url).await.unwrap();
+        assert_eq!(
+            read_capped_text(response, 1024).await,
+            Some("hosts".to_string())
+        );
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod game_launch_service;
 pub mod ggm_hotfix;
 pub mod ggm_launch;
 pub mod github_hosts;
+pub mod http_util;
 pub mod local_proxy;
 pub mod log_service;
 pub mod lr_service;

--- a/src-tauri/src/services/network_service.rs
+++ b/src-tauri/src/services/network_service.rs
@@ -36,7 +36,13 @@ pub async fn geo_lookup(client: &reqwest::Client) -> (String, String) {
     // would otherwise hold the accelerator hint open for as long as it liked.
     // The answer is optional — an empty one costs a hint, not a launch.
     match client.get(url).timeout(GEO_TIMEOUT).send().await {
-        Ok(resp) => match resp.json::<serde_json::Value>().await {
+        // Three fields, about a hundred bytes. Read to a bound like everything
+        // else that comes from somewhere we do not run.
+        Ok(resp) => match crate::services::http_util::read_capped_text(resp, 64 * 1024)
+            .await
+            .ok_or(())
+            .and_then(|b| serde_json::from_str::<serde_json::Value>(&b).map_err(|_| ()))
+        {
             Ok(j) => (
                 j["query"].as_str().unwrap_or_default().to_string(),
                 j["countryCode"].as_str().unwrap_or_default().to_string(),

--- a/src-tauri/src/services/network_service.rs
+++ b/src-tauri/src/services/network_service.rs
@@ -2,6 +2,11 @@
 //! China-specific hints (e.g. the "rename to Beanfun.exe" accelerator
 //! suggestion). No DNS changes are made — that feature was removed.
 
+/// How long the country is worth waiting for. Nothing blocks on it, but a
+/// failed lookup is not cached, so a short one also means the next caller gets
+/// another try rather than inheriting a stalled one.
+const GEO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Cached result of [`geo_lookup`], so the startup checks that each need the
 /// country don't each pay for their own request.
 static GEO_CACHE: std::sync::OnceLock<(String, String)> = std::sync::OnceLock::new();
@@ -26,7 +31,11 @@ pub async fn geo_lookup_cached(client: &reqwest::Client) -> (String, String) {
 /// failure. Best-effort — never errors.
 pub async fn geo_lookup(client: &reqwest::Client) -> (String, String) {
     let url = "http://ip-api.com/json/?fields=status,countryCode,query";
-    match client.get(url).send().await {
+    // The only request in the app with no deadline of its own, and it runs at
+    // startup: a third party that accepts the connection and then says nothing
+    // would otherwise hold the accelerator hint open for as long as it liked.
+    // The answer is optional — an empty one costs a hint, not a launch.
+    match client.get(url).timeout(GEO_TIMEOUT).send().await {
         Ok(resp) => match resp.json::<serde_json::Value>().await {
             Ok(j) => (
                 j["query"].as_str().unwrap_or_default().to_string(),

--- a/src-tauri/src/services/update_service.rs
+++ b/src-tauri/src/services/update_service.rs
@@ -14,7 +14,7 @@ use std::sync::OnceLock;
 
 use crate::core::error::UpdateError;
 use crate::models::update::UpdateInfo;
-use crate::services::github_hosts;
+use crate::services::{github_hosts, http_util};
 
 /// GitHub API endpoint for latest release.
 const GITHUB_API_URL: &str = "https://api.github.com/repos/lshw54/maplelink/releases/latest";
@@ -53,23 +53,19 @@ fn download_buffer_capacity(declared: u64) -> usize {
     declared.min(MAX_UPDATE_BYTES) as usize
 }
 
-/// Read a response body, stopping at `limit` rather than at whatever the sender
-/// decides to send.
-async fn read_capped(response: reqwest::Response, limit: u64) -> Result<Vec<u8>, String> {
-    use futures_util::StreamExt;
+/// How much release metadata is worth reading. Thirty releases with their
+/// assets is well under a megabyte; this is room to spare, and a stop on a
+/// mirror answering the API with something else.
+const MAX_RELEASE_JSON_BYTES: u64 = 8 * 1024 * 1024;
 
-    let mut body: Vec<u8> = Vec::with_capacity(download_buffer_capacity(
-        response.content_length().unwrap_or(0),
-    ));
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("{e}"))?;
-        if body.len() as u64 + chunk.len() as u64 > limit {
-            return Err(format!("the body ran past {limit} bytes"));
-        }
-        body.extend_from_slice(&chunk);
-    }
-    Ok(body)
+/// Read a release listing, bounded.
+async fn read_release_json(response: reqwest::Response) -> Result<serde_json::Value, UpdateError> {
+    let body = http_util::read_capped(response, MAX_RELEASE_JSON_BYTES)
+        .await
+        .map_err(|reason| UpdateError::CheckFailed { reason })?;
+    serde_json::from_slice(&body).map_err(|e| UpdateError::CheckFailed {
+        reason: format!("invalid response: {e}"),
+    })
 }
 
 /// Cached connectivity probe result.
@@ -323,13 +319,7 @@ pub async fn check_for_update(
         let list_url =
             maybe_proxy_url("https://api.github.com/repos/lshw54/maplelink/releases?per_page=30");
         if let Some(response) = github_get(client, &list_url).await? {
-            let body: serde_json::Value =
-                response
-                    .json()
-                    .await
-                    .map_err(|e| UpdateError::CheckFailed {
-                        reason: format!("invalid response: {e}"),
-                    })?;
+            let body: serde_json::Value = read_release_json(response).await?;
             for release in body.as_array().map(|a| a.as_slice()).unwrap_or(&[]) {
                 let tag = release["tag_name"]
                     .as_str()
@@ -347,13 +337,7 @@ pub async fn check_for_update(
         // Newest stable — covers the list-omission quirk above.
         let latest_url = maybe_proxy_url(GITHUB_API_URL);
         if let Some(response) = github_get(client, &latest_url).await? {
-            let release: serde_json::Value =
-                response
-                    .json()
-                    .await
-                    .map_err(|e| UpdateError::CheckFailed {
-                        reason: format!("invalid response: {e}"),
-                    })?;
+            let release: serde_json::Value = read_release_json(response).await?;
             if !release.is_null() {
                 let tag = release["tag_name"]
                     .as_str()
@@ -382,13 +366,7 @@ pub async fn check_for_update(
             None => return Ok(None),
         };
 
-        let release: serde_json::Value =
-            response
-                .json()
-                .await
-                .map_err(|e| UpdateError::CheckFailed {
-                    reason: format!("invalid response: {e}"),
-                })?;
+        let release: serde_json::Value = read_release_json(response).await?;
 
         if release.is_null() {
             return Ok(None);
@@ -618,7 +596,7 @@ pub async fn download_update_with_progress(
 
             // Same mirror, same ceiling — `bytes()` would read whatever it is
             // given.
-            let bytes = read_capped(fallback_resp, MAX_UPDATE_BYTES)
+            let bytes = http_util::read_capped(fallback_resp, MAX_UPDATE_BYTES)
                 .await
                 .map_err(|reason| UpdateError::DownloadFailed {
                     reason: format!("fallback read error: {reason}"),

--- a/src-tauri/src/services/update_service.rs
+++ b/src-tauri/src/services/update_service.rs
@@ -37,6 +37,41 @@ const PROXY_MIRRORS: &[&str] = &[
     "https://ghproxy.cc/",
 ];
 
+/// A ceiling on the update itself. The build is ~12 MB and the largest shipped
+/// was 23 MB, so this is several times any real one — it bounds what a mirror
+/// can make us hold, not what a build may weigh.
+const MAX_UPDATE_BYTES: u64 = 256 * 1024 * 1024;
+
+/// How much to reserve up front for a download that declares `declared` bytes.
+///
+/// `Content-Length` is whatever the mirror said, and the mirrors are third
+/// parties. Unclamped, one answering `Content-Length: 999999999999` had us ask
+/// the allocator for 931 GB before a single byte arrived — which fails, and a
+/// failed allocation aborts the process. Not a panic: no unwind, no message the
+/// user sees, the app is simply gone mid-update.
+fn download_buffer_capacity(declared: u64) -> usize {
+    declared.min(MAX_UPDATE_BYTES) as usize
+}
+
+/// Read a response body, stopping at `limit` rather than at whatever the sender
+/// decides to send.
+async fn read_capped(response: reqwest::Response, limit: u64) -> Result<Vec<u8>, String> {
+    use futures_util::StreamExt;
+
+    let mut body: Vec<u8> = Vec::with_capacity(download_buffer_capacity(
+        response.content_length().unwrap_or(0),
+    ));
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("{e}"))?;
+        if body.len() as u64 + chunk.len() as u64 > limit {
+            return Err(format!("the body ran past {limit} bytes"));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
 /// Cached connectivity probe result.
 /// - `None` inside the Option = direct GitHub works (no proxy needed)
 /// - `Some(prefix)` = use this proxy prefix for GitHub URLs
@@ -517,7 +552,7 @@ pub async fn download_update_with_progress(
     // fall back to a simple non-streaming download.
     let buf = {
         let mut downloaded: u64 = 0;
-        let mut buf = Vec::with_capacity(total as usize);
+        let mut buf = Vec::with_capacity(download_buffer_capacity(total));
         let mut stream = response.bytes_stream();
         let start = std::time::Instant::now();
         let mut last_emit = std::time::Instant::now();
@@ -526,6 +561,16 @@ pub async fn download_update_with_progress(
         while let Some(chunk_result) = stream.next().await {
             match chunk_result {
                 Ok(chunk) => {
+                    // The clamp only bounds the reservation. A sender free to
+                    // lie about the length is equally free to keep sending, so
+                    // what actually arrives is counted too.
+                    if downloaded + chunk.len() as u64 > MAX_UPDATE_BYTES {
+                        return Err(UpdateError::DownloadFailed {
+                            reason: format!(
+                                "the download ran past {MAX_UPDATE_BYTES} bytes without ending"
+                            ),
+                        });
+                    }
                     downloaded += chunk.len() as u64;
                     buf.extend_from_slice(&chunk);
 
@@ -571,11 +616,12 @@ pub async fn download_update_with_progress(
                     reason: format!("fallback network error: {e}"),
                 })?;
 
-            let bytes = fallback_resp
-                .bytes()
+            // Same mirror, same ceiling — `bytes()` would read whatever it is
+            // given.
+            let bytes = read_capped(fallback_resp, MAX_UPDATE_BYTES)
                 .await
-                .map_err(|e| UpdateError::DownloadFailed {
-                    reason: format!("fallback read error: {e}"),
+                .map_err(|reason| UpdateError::DownloadFailed {
+                    reason: format!("fallback read error: {reason}"),
                 })?;
 
             let _ = app_handle.emit(
@@ -894,6 +940,40 @@ mod tests {
         fn prop_enabled_auto_update_allows_background_check(_dummy in 0u8..10) {
             prop_assert!(should_check(false, true));
         }
+    }
+
+    /// A real update sizes its own buffer.
+    #[test]
+    fn an_honest_length_is_reserved_in_full() {
+        let real = 11_800_000;
+        assert_eq!(download_buffer_capacity(real), real as usize);
+    }
+
+    /// A claimed one cannot. 999999999999 is what the repro used; unclamped it
+    /// aborted the process with 0xC0000409 before any byte was read.
+    #[test]
+    fn a_claimed_length_cannot_reserve_more_than_a_real_update() {
+        assert_eq!(
+            download_buffer_capacity(999_999_999_999),
+            MAX_UPDATE_BYTES as usize
+        );
+        assert_eq!(
+            download_buffer_capacity(u64::MAX),
+            MAX_UPDATE_BYTES as usize
+        );
+    }
+
+    /// The clamp must not be so generous that it is the same bug in slow motion:
+    /// whatever is reserved has to be an amount a machine can actually give.
+    #[test]
+    fn the_ceiling_is_an_allocatable_amount() {
+        let ceiling = download_buffer_capacity(u64::MAX);
+        assert!(
+            ceiling <= 512 * 1024 * 1024,
+            "{ceiling} is too much to hold"
+        );
+        let buf: Vec<u8> = Vec::with_capacity(ceiling);
+        assert_eq!(buf.capacity(), ceiling);
     }
 
     // ----- self-replace -------------------------------------------------

--- a/src-tauri/src/services/update_service.rs
+++ b/src-tauri/src/services/update_service.rs
@@ -58,6 +58,24 @@ fn download_buffer_capacity(declared: u64) -> usize {
 /// mirror answering the API with something else.
 const MAX_RELEASE_JSON_BYTES: u64 = 8 * 1024 * 1024;
 
+/// How long the download may go without producing a byte.
+///
+/// This replaces a 300-second cap on the request *as a whole*, which is a
+/// different thing entirely: 11.8 MB inside 300 s demands a sustained 40 KB/s,
+/// and a mainland user on a slow ghproxy mirror is often under that. Those
+/// downloads were being cut off at five minutes for making steady progress —
+/// exactly the users the mirrors exist for.
+///
+/// What deserves a deadline is silence, not slowness. A mirror that stops
+/// sending is finished with us; one that trickles is still working.
+const DOWNLOAD_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// A ceiling on the download regardless of progress, so a mirror sending one
+/// byte a minute cannot hold the update open indefinitely. Thirty minutes is
+/// about 6 KB/s for a 12 MB build — slower than anything worth waiting for, and
+/// far below what the old total timeout demanded.
+const DOWNLOAD_TOTAL_LIMIT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
 /// Read a release listing, bounded.
 async fn read_release_json(response: reqwest::Response) -> Result<serde_json::Value, UpdateError> {
     let body = http_util::read_capped(response, MAX_RELEASE_JSON_BYTES)
@@ -509,7 +527,7 @@ pub async fn download_update_with_progress(
     let response = client
         .get(download_url)
         .header("User-Agent", "MapleLink-Updater")
-        .timeout(std::time::Duration::from_secs(300))
+        // No total timeout: the deadlines that apply here are per-chunk, below.
         .send()
         .await
         .map_err(|e| UpdateError::DownloadFailed {
@@ -536,7 +554,27 @@ pub async fn download_update_with_progress(
         let mut last_emit = std::time::Instant::now();
         let mut stream_failed = false;
 
-        while let Some(chunk_result) = stream.next().await {
+        while let Some(chunk_result) =
+            match tokio::time::timeout(DOWNLOAD_IDLE_TIMEOUT, stream.next()).await {
+                Ok(next) => next,
+                Err(_) => {
+                    return Err(UpdateError::DownloadFailed {
+                        reason: format!(
+                            "the mirror stopped sending for {} seconds",
+                            DOWNLOAD_IDLE_TIMEOUT.as_secs()
+                        ),
+                    })
+                }
+            }
+        {
+            if start.elapsed() > DOWNLOAD_TOTAL_LIMIT {
+                return Err(UpdateError::DownloadFailed {
+                    reason: format!(
+                        "the download was still going after {} minutes",
+                        DOWNLOAD_TOTAL_LIMIT.as_secs() / 60
+                    ),
+                });
+            }
             match chunk_result {
                 Ok(chunk) => {
                     // The clamp only bounds the reservation. A sender free to
@@ -587,7 +625,8 @@ pub async fn download_update_with_progress(
             let fallback_resp = client
                 .get(download_url)
                 .header("User-Agent", "MapleLink-Updater")
-                .timeout(std::time::Duration::from_secs(300))
+                // Bounded by `DOWNLOAD_TOTAL_LIMIT` below rather than by a cap
+                // a slow mirror would trip while working.
                 .send()
                 .await
                 .map_err(|e| UpdateError::DownloadFailed {
@@ -596,11 +635,20 @@ pub async fn download_update_with_progress(
 
             // Same mirror, same ceiling — `bytes()` would read whatever it is
             // given.
-            let bytes = http_util::read_capped(fallback_resp, MAX_UPDATE_BYTES)
-                .await
-                .map_err(|reason| UpdateError::DownloadFailed {
-                    reason: format!("fallback read error: {reason}"),
-                })?;
+            let bytes = tokio::time::timeout(
+                DOWNLOAD_TOTAL_LIMIT,
+                http_util::read_capped(fallback_resp, MAX_UPDATE_BYTES),
+            )
+            .await
+            .map_err(|_| UpdateError::DownloadFailed {
+                reason: format!(
+                    "the download was still going after {} minutes",
+                    DOWNLOAD_TOTAL_LIMIT.as_secs() / 60
+                ),
+            })?
+            .map_err(|reason| UpdateError::DownloadFailed {
+                reason: format!("fallback read error: {reason}"),
+            })?;
 
             let _ = app_handle.emit(
                 "update-download-progress",


### PR DESCRIPTION
Every HTTP client now verifies certificates, every request has a deadline, and every body read from somewhere we don't run has a size limit.

**Certificates.** `danger_accept_invalid_certs(true)` was on the shared client and all three beanfun ones — it dates from the initial commit and was never a fix for anything. Checked on real users' machines under AK, UU and LeiGod, as `Beanfun.exe` (they match by process name): 18 checks, none rejected. beanfun serves Amazon certs, GitHub serves Sectigo.

**Timeouts.** The download had a 300s *total* cap — 11.8 MB in 300s is a sustained 40 KB/s, which cuts off mainland users who are downloading fine, just slowly. Replaced with a 60s idle timeout per chunk plus a 30-minute ceiling; connect timeouts added where clients had none. Deliberately no global timeout, and the comment says why.

**Bodies.** Found worse than "no limit": the download buffer was pre-allocated from `Content-Length`, so a mirror claiming an absurd length made us ask the allocator for it before a byte arrived — allocation fails, process aborts, no panic, no message. Reproduced locally. Now clamped, counted as it streams, and the release JSON, hosts list, hotfix file, DoH answers and geo lookup all read through one bounded helper.

Also: `geo_lookup` and one beanfun client had no deadline at all.

Left alone: 13 unbounded reads in `beanfun_service.rs` (time-bounded at 30s), and HTTP version pinning — beanfun already pins `http1_only` for fingerprinting, and not pinning GitHub is correct.

## How to test

Update check + download, TW and HK login, OTP. Behind an accelerator if you can.