### PR TITLE
feat(update): verify the downloaded update against a key we hold

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,32 @@ jobs:
           Write-Host "SHA256: $hash"
           Write-Host "Size: $size bytes"
 
+      # The one thing a proxy mirror cannot produce. Users on the mirrors reach
+      # a third party that terminates TLS legitimately and could serve any bytes
+      # it liked; the app checks this against a key compiled into it, so what it
+      # verifies is that we built the file rather than that someone with a valid
+      # certificate handed it over. Unrelated to Authenticode — that is what
+      # SmartScreen reads, and this is invisible to it.
+      - name: Sign the update
+        shell: pwsh
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.UPDATE_SIGNING_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.UPDATE_SIGNING_KEY_PASSWORD }}
+        run: |
+          if (-not $env:TAURI_SIGNING_PRIVATE_KEY) {
+            # Refused rather than released: an unsigned build is one every
+            # updated client will reject, and finding that out from users is a
+            # worse way to learn the secret is missing.
+            Write-Error "UPDATE_SIGNING_KEY is not set - the release would be unverifiable"
+            exit 1
+          }
+          npx @tauri-apps/cli@2.11.1 signer sign MapleLink.exe
+          if (-not (Test-Path "MapleLink.exe.sig")) {
+            Write-Error "signing produced no MapleLink.exe.sig"
+            exit 1
+          }
+          Write-Host "signature: $((Get-Item 'MapleLink.exe.sig').Length) bytes"
+
       - name: Build self-extracting package (new users)
         id: sfx
         shell: pwsh
@@ -279,6 +305,7 @@ jobs:
             </details>
           files: |
             MapleLink.exe
+            MapleLink.exe.sig
             MapleLink-Setup.exe
           draft: false
           prerelease: ${{ github.event.inputs.release_type == 'prerelease' }}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2046,6 +2046,7 @@ dependencies = [
  "des",
  "futures-util",
  "hex",
+ "minisign-verify",
  "open",
  "proptest",
  "rand 0.10.1",
@@ -2113,6 +2114,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ aes-gcm = "0.10"
 argon2 = "0.5"
 # Move an imported backup file to the OS recycle bin (user's choice).
 trash = "5"
+minisign-verify = "0.2.5"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.56"

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -25,6 +25,7 @@ pub mod process_service;
 pub mod recaptcha_window;
 pub mod session_key_fallback;
 pub mod update_service;
+pub mod update_signature;
 pub mod web_launch;
 pub mod web_popup_service;
 pub mod webview_login;

--- a/src-tauri/src/services/update_service.rs
+++ b/src-tauri/src/services/update_service.rs
@@ -14,7 +14,7 @@ use std::sync::OnceLock;
 
 use crate::core::error::UpdateError;
 use crate::models::update::UpdateInfo;
-use crate::services::{github_hosts, http_util};
+use crate::services::{github_hosts, http_util, update_signature};
 
 /// GitHub API endpoint for latest release.
 const GITHUB_API_URL: &str = "https://api.github.com/repos/lshw54/maplelink/releases/latest";
@@ -681,7 +681,55 @@ pub async fn download_update_with_progress(
     }
 
     tracing::info!("downloaded {} bytes", buf.len());
+
+    // Verified here rather than by the caller, so that no path to a downloaded
+    // update exists that skips it.
+    let signature = fetch_signature(client, download_url).await?;
+    update_signature::verify(&buf, &signature)?;
+    tracing::info!("update signature verified");
+
     Ok(buf)
+}
+
+/// Fetch the `.sig` published beside the asset.
+///
+/// Asked for through the same URL the bytes came from, mirror prefix and all:
+/// there is no advantage in a different route, since the signature is checked
+/// against a key compiled in here rather than against whoever served it. A
+/// mirror can withhold it or corrupt it, and then the update does not happen —
+/// which is the correct outcome for bytes we cannot identify.
+async fn fetch_signature(
+    client: &reqwest::Client,
+    download_url: &str,
+) -> Result<String, UpdateError> {
+    /// Minisign signatures are a few hundred bytes.
+    const MAX_SIGNATURE_BYTES: u64 = 8 * 1024;
+
+    let url = format!("{download_url}.sig");
+    let response = client
+        .get(&url)
+        .header("User-Agent", "MapleLink-Updater")
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| UpdateError::DownloadFailed {
+            reason: format!("could not fetch the update signature: {e}"),
+        })?;
+
+    if !response.status().is_success() {
+        return Err(UpdateError::DownloadFailed {
+            reason: format!(
+                "the update signature is missing (HTTP {} from {url})",
+                response.status()
+            ),
+        });
+    }
+
+    http_util::read_capped_text(response, MAX_SIGNATURE_BYTES)
+        .await
+        .ok_or_else(|| UpdateError::DownloadFailed {
+            reason: "the update signature could not be read".to_string(),
+        })
 }
 
 /// Download, self-replace, and prompt restart.

--- a/src-tauri/src/services/update_signature.rs
+++ b/src-tauri/src/services/update_signature.rs
@@ -1,0 +1,151 @@
+//! Proof that an update came from us.
+//!
+//! Certificate validation authenticates whoever answered, and on the route most
+//! mainland users take that is a ghproxy mirror — a third party that terminates
+//! TLS legitimately, holds a valid certificate for its own name, and could serve
+//! any bytes it liked with the handshake still perfect. The release listing
+//! comes through the same mirror, so publishing a hash in it would only mean
+//! asking the same party twice.
+//!
+//! A signature is the one thing a mirror cannot produce. The key that makes it
+//! never leaves the release workflow; the key that checks it is compiled in
+//! here, so what is verified is "we built this", not "someone with a valid
+//! certificate handed it over".
+//!
+//! This is not code signing. Authenticode is a separate problem with a price
+//! tag, and it is what Windows SmartScreen and Defender read; this is invisible
+//! to them and answers a different question.
+
+use base64::Engine;
+
+use crate::core::error::UpdateError;
+
+/// The public half of the key releases are signed with.
+///
+/// Base64 of a minisign public key file, as printed by
+/// `npx @tauri-apps/cli signer generate`. Changing it invalidates every update
+/// signed with the old key, so it changes only if the private half is lost or
+/// compromised — and then the release before the change has to be installed by
+/// hand, since no build after it will verify against what users already have.
+const UPDATE_PUBLIC_KEY: &str = "";
+
+/// Whether a public key has been published yet.
+///
+/// Until it has, an update cannot be shown to be ours, and the alternative to
+/// refusing is running an unidentified executable — which is the thing this
+/// exists to stop.
+pub fn signing_configured() -> bool {
+    !UPDATE_PUBLIC_KEY.is_empty()
+}
+
+/// Check `bytes` against `signature`, which is the content of the `.sig` file
+/// published beside the release asset.
+pub fn verify(bytes: &[u8], signature: &str) -> Result<(), UpdateError> {
+    verify_with_key(bytes, signature, UPDATE_PUBLIC_KEY)
+}
+
+/// [`verify`] against a stated key, so the tests can exercise it with one whose
+/// private half is a throwaway.
+fn verify_with_key(bytes: &[u8], signature: &str, public_key: &str) -> Result<(), UpdateError> {
+    let fail = |what: &str| UpdateError::DownloadFailed {
+        reason: format!("the update could not be shown to be ours: {what}"),
+    };
+
+    if public_key.is_empty() {
+        return Err(fail("no signing key is published"));
+    }
+
+    // Both halves are base64 around an ordinary minisign file, which is how the
+    // Tauri signer writes them.
+    let decode = |s: &str, what: &str| -> Result<String, UpdateError> {
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(s.trim())
+            .map_err(|_| fail(&format!("the {what} is not base64")))?;
+        String::from_utf8(raw).map_err(|_| fail(&format!("the {what} is not text")))
+    };
+
+    let key = minisign_verify::PublicKey::decode(&decode(public_key, "public key")?)
+        .map_err(|e| fail(&format!("the public key is unusable ({e})")))?;
+    let sig = minisign_verify::Signature::decode(&decode(signature, "signature")?)
+        .map_err(|e| fail(&format!("the signature is unreadable ({e})")))?;
+
+    key.verify(bytes, &sig, false)
+        .map_err(|_| fail("the signature does not match these bytes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A throwaway keypair, generated for these tests alone. Its private half
+    /// was never used for anything and is not kept — the point is only that
+    /// these are a real minisign key and a real signature over known bytes.
+    const TEST_PUBLIC_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhGM0IwMDEyMzZBNkU1RjYKUldUMjVhWTJFZ0E3andncEVhbVl0V2FTTlhkUzhMcVlXT3VqYy80Uis4QTB4VTlKb3E5eG02Qi8K";
+
+    /// The signature that key produced over `TEST_BYTES`.
+    const TEST_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUMjVhWTJFZ0E3ajdrc0tSVkN3UU9nYXdpT0c0TzdRWFhVQjg1QjBBTHMrRjBRWDN2MXNseit0Y3dmbFBPWDVVTUlLUStseUVMUG1xNUVVVmxHcDZNTmJNYzlrRHMyZkFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3ODQ4MDc4CWZpbGU6c2FtcGxlLmJpbgpudWdxaFRCSUNqcE82NGJNWWN0Z1NzWmdEY3Zoem9XdDI2d3RtbjlrRWk1TkNyWEEwbENCay9lUndQT2Uwd0pWaklHWVRqRFNHTDNUVGpZRG85ZXBDUT09Cg==";
+
+    const TEST_BYTES: &[u8] = b"pretend this is MapleLink.exe";
+
+    #[test]
+    fn a_signature_over_these_bytes_verifies() {
+        verify_with_key(TEST_BYTES, TEST_SIGNATURE, TEST_PUBLIC_KEY).unwrap();
+    }
+
+    /// The case this exists for: a mirror serves a different executable and the
+    /// signature it was given no longer describes it.
+    #[test]
+    fn substituted_bytes_are_refused() {
+        let swapped = b"pretend this is someone else's exe";
+        let err = verify_with_key(swapped, TEST_SIGNATURE, TEST_PUBLIC_KEY).unwrap_err();
+        assert!(err.to_string().contains("does not match"), "got: {err}");
+    }
+
+    /// A single flipped byte is enough.
+    #[test]
+    fn one_altered_byte_is_refused() {
+        let mut tampered = TEST_BYTES.to_vec();
+        tampered[0] ^= 0x01;
+        verify_with_key(&tampered, TEST_SIGNATURE, TEST_PUBLIC_KEY).unwrap_err();
+    }
+
+    /// A mirror that forges a whole signature has to forge it under our key,
+    /// which is the part it cannot do.
+    #[test]
+    fn a_signature_from_another_key_is_refused() {
+        // Same shape, different key: the signer's own public key rather than
+        // ours, which is what an attacker with a keypair would have.
+        let other = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDBBMEEwQTBBMEEwQTBBMEEKUldRS0Nnb0tDZ29LQ2dvS0Nnb0tDZ29LQ2dvS0Nnb0tDZ29LQ2dvS0Nnb0tDZ29LQ2dvSwo=";
+        verify_with_key(TEST_BYTES, TEST_SIGNATURE, other).unwrap_err();
+    }
+
+    #[test]
+    fn rubbish_in_place_of_a_signature_is_refused() {
+        for bad in ["", "not base64!!", "aGVsbG8="] {
+            verify_with_key(TEST_BYTES, bad, TEST_PUBLIC_KEY).unwrap_err();
+        }
+    }
+
+    /// Nothing verifies against an unset key — including, deliberately, a valid
+    /// signature. Better a refused update than an unidentified one.
+    #[test]
+    fn an_unpublished_key_verifies_nothing() {
+        assert!(verify_with_key(TEST_BYTES, TEST_SIGNATURE, "").is_err());
+    }
+
+    /// Fails until the key is published, which is the point: it is the one step
+    /// that cannot be done from inside the repository, and a green build would
+    /// hide that the protection is not on yet.
+    #[test]
+    #[ignore = "enable once UPDATE_PUBLIC_KEY is filled in"]
+    fn the_shipped_key_is_a_real_one() {
+        assert!(signing_configured(), "UPDATE_PUBLIC_KEY is still empty");
+        // Wrong bytes, real key: reaching "does not match" proves the key
+        // parsed, without needing a signature made by the private half.
+        let err = verify(b"not the release", TEST_SIGNATURE).unwrap_err();
+        assert!(
+            err.to_string().contains("does not match"),
+            "the shipped key did not parse: {err}"
+        );
+    }
+}

--- a/src-tauri/src/services/update_signature.rs
+++ b/src-tauri/src/services/update_signature.rs
@@ -27,7 +27,7 @@ use crate::core::error::UpdateError;
 /// signed with the old key, so it changes only if the private half is lost or
 /// compromised — and then the release before the change has to be installed by
 /// hand, since no build after it will verify against what users already have.
-const UPDATE_PUBLIC_KEY: &str = "";
+const UPDATE_PUBLIC_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY0QjNCMTlCQkYzQjEzRDEKUldUUkV6dS9tN0d6Wkwrb2IrZm5ISTZrdEsrNTZUdytncVFSdjdoV0NiU2IvK3o0N3lvNUVCQXkK";
 
 /// Whether a public key has been published yet.
 ///
@@ -133,11 +133,9 @@ mod tests {
         assert!(verify_with_key(TEST_BYTES, TEST_SIGNATURE, "").is_err());
     }
 
-    /// Fails until the key is published, which is the point: it is the one step
-    /// that cannot be done from inside the repository, and a green build would
-    /// hide that the protection is not on yet.
+    /// The key that ships is a real minisign key, and the one releases are
+    /// signed with. Its fingerprint is 64B3B19BBF3B13D1.
     #[test]
-    #[ignore = "enable once UPDATE_PUBLIC_KEY is filled in"]
     fn the_shipped_key_is_a_real_one() {
         assert!(signing_configured(), "UPDATE_PUBLIC_KEY is still empty");
         // Wrong bytes, real key: reaching "does not match" proves the key


### PR DESCRIPTION
Verifying certificates doesn't cover the mirror path: ghproxy is a legitimate man-in-the-middle by design — you connect to the mirror, it holds a valid certificate for its own name, and it can return anything. The release JSON comes through the same mirror, so putting a hash in it means asking the same party twice. A signature is the one thing it can't produce.

CI signs `MapleLink.exe` with minisign and publishes `MapleLink.exe.sig`; the app fetches it alongside the download and checks it against a public key compiled in, before anything is written to disk. Nothing to buy — this is not Authenticode, and it is invisible to SmartScreen and Defender.

Key fingerprint `64B3B19BBF3B13D1`. `UPDATE_SIGNING_KEY` and `UPDATE_SIGNING_KEY_PASSWORD` are set; CI refuses to release without them rather than shipping a build every updated client would reject.

Losing the private key means nobody can update again — back it up somewhere it can't be lost with the machine.

Users on 0.5.0 don't verify, so they reach the first signed release unverified; everyone after that is covered.

## Not yet exercised

The signing step has never run. Verification is covered by tests — a substituted binary, a single flipped byte, a signature made by a different key — but CI producing a `.sig` that this key accepts has not been observed end to end. Worth a prerelease before a real one.

Replaces #87, which GitHub closed when its base branch was deleted on merge.