### PR TITLE
fix(qr): refresh, copy, countdown, and a window sized for the view

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -165,6 +165,12 @@ pub async fn resize_window(
         // button; the compact window grows to fit them rather than scroll.
         "login-classic" if compact => (350.0, 570.0 + bar),
         "login" | "login-classic" => (350.0, 620.0 + bar),
+        // The QR view is taller than the form it replaces: a code, a row of
+        // actions, and two lines saying what is happening and how long is left.
+        // Sharing the login height meant the compact window scrolled, and the
+        // back button sat on top of the status line.
+        "login-qr" if compact => (350.0, 545.0 + bar),
+        "login-qr" => (350.0, 650.0 + bar),
         "login-enlarged" => (540.0, 780.0 + bar),
         "main" if compact => (340.0, 340.0 + bar),
         "main" => (760.0, 530.0 + bar),

--- a/src/features/login/NormalLoginForm.tsx
+++ b/src/features/login/NormalLoginForm.tsx
@@ -54,6 +54,8 @@ export function NormalLoginForm({
   const [cafeConfirm, setCafeConfirm] = useState(false);
   const [classicCheck, setClassicCheck] = useState<ClassicCheckDto | null>(null);
   const [showCheckDetail, setShowCheckDetail] = useState(false);
+  /** Why a press did nothing, when it never got as far as the mutation. */
+  const [formError, setFormError] = useState<string | null>(null);
 
   async function runClassicCheck() {
     try {
@@ -268,7 +270,23 @@ export function NormalLoginForm({
 
   function handleSubmit(e: SyntheticEvent) {
     e.preventDefault();
-    if (!account.trim() || !password.trim()) return;
+    // Said out loud rather than returned from silently. A press that produces
+    // no request, no message and no log entry is indistinguishable from a
+    // failed login, and was reported as one — the debug log showed the attempt
+    // never reaching the backend at all, with nothing to say why.
+    if (!account.trim() || !password.trim()) {
+      const missing = !account.trim() ? t("login.username") : t("login.password");
+      setFormError(t("login.error.required", { field: missing }));
+      commands
+        .logFrontendError(
+          "warn",
+          "NormalLoginForm",
+          `submit ignored: ${!account.trim() ? "account" : "password"} is empty`,
+        )
+        .catch(() => {});
+      return;
+    }
+    setFormError(null);
 
     // Classic: if this account is already logged in, reuse that session's cookies
     // to open the portal instead of logging in again. beanfun allows one session
@@ -523,8 +541,8 @@ export function NormalLoginForm({
         </span>
       </label>
 
-      {login.error && (
-        <p className="mb-2 text-[12px] text-[var(--danger)]">{login.error.message}</p>
+      {(formError ?? login.error) && (
+        <p className="mb-2 text-[12px] text-[var(--danger)]">{formError ?? login.error?.message}</p>
       )}
 
       {/* Actions row: Sign In + QR button (QR only for TW) */}

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -7,6 +7,28 @@ import { useConfigStore } from "../../lib/stores/config-store";
 import { autoLaunchGameIfEnabled } from "../../lib/hooks/use-auth";
 import type { QrCodeData, QrPollResult } from "../../lib/types";
 
+/**
+ * The QR image as a PNG blob, decoded from the `data:` URL it arrives in.
+ *
+ * Decoded rather than fetched, and synchronously, because `clipboard.write`
+ * needs the click that called it to still be in progress. Awaiting a `fetch`
+ * first — even of a `data:` URL, even for microseconds — spends that activation,
+ * and Chromium then rejects the write with `NotAllowedError`. That was the whole
+ * bug: the button worked exactly as written and the browser refused it.
+ */
+function pngFromDataUrl(url: string): Blob | null {
+  const comma = url.indexOf(",");
+  if (comma < 0 || !url.startsWith("data:image/png;base64,")) return null;
+  try {
+    const binary = atob(url.slice(comma + 1));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new Blob([bytes], { type: "image/png" });
+  } catch {
+    return null;
+  }
+}
+
 interface QrLoginFormProps {
   onBack: () => void;
 }
@@ -25,6 +47,8 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
   const [enlarged, setEnlarged] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const startedRef = useRef(false);
+  /** Consecutive failed polls, to tell a blink apart from a dead session. */
+  const failures = useRef(0);
   const sessionIdRef = useRef<string | null>(useUiStore.getState().qrSessionId);
 
   function stopPolling() {
@@ -36,6 +60,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
 
   function startPolling(sessionId: string, data: QrCodeData) {
     stopPolling();
+    failures.current = 0;
     intervalRef.current = setInterval(async () => {
       try {
         const result: QrPollResult = await commands.qrLoginPoll(
@@ -73,8 +98,17 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
           setStatus("expired");
           useUiStore.setState({ qrSessionId: null, qrData: null });
         }
+        failures.current = 0;
       } catch {
-        // Poll error — ignore, will retry
+        // One failed poll is nothing — the network blinks. A run of them means
+        // the session is no longer answering, and saying so is more honest than
+        // showing a code that cannot be scanned.
+        failures.current += 1;
+        if (failures.current >= 5) {
+          stopPolling();
+          setStatus("expired");
+          useUiStore.setState({ qrSessionId: null, qrData: null });
+        }
       }
     }, 2000);
   }
@@ -119,7 +153,11 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
   }
 
   function handleRefresh() {
+    stopPolling();
     sessionIdRef.current = null;
+    // Cleared, not just replaced: if the new code never arrives, the old one
+    // must not sit there next to an error message looking scannable.
+    setQrData(null);
     useUiStore.setState({ qrSessionId: null, qrData: null });
     startedRef.current = false;
     startQr();
@@ -188,15 +226,18 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
             <button
               type="button"
               onClick={async () => {
-                if (!qrData?.qrImageUrl) return;
+                const blob = qrData?.qrImageUrl ? pngFromDataUrl(qrData.qrImageUrl) : null;
+                if (!blob) return;
                 try {
-                  const resp = await fetch(qrData.qrImageUrl);
-                  const blob = await resp.blob();
-                  await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+                  await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
                   setCopied(true);
                   setTimeout(() => setCopied(false), 1500);
-                } catch {
-                  /* clipboard write failed */
+                } catch (e) {
+                  // Silence here is why this went unreported as broken for so
+                  // long: the button simply did nothing.
+                  commands
+                    .logFrontendError("warn", "QrLoginForm", `copying the QR image failed: ${e}`)
+                    .catch(() => {});
                 }
               }}
               title={t("login.qr.copy")}
@@ -326,15 +367,23 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
         )}
       </div>
 
-      {status === "expired" && (
-        <button
-          type="button"
-          onClick={handleRefresh}
-          className="mt-4 w-full rounded-lg bg-accent px-4 py-2.5 text-[12px] font-semibold tracking-[1.5px] text-[var(--on-accent)] uppercase hover:opacity-90"
-        >
-          {t("login.qr.refresh")}
-        </button>
-      )}
+      {/* Always offered, not only once the poll has noticed the code is dead.
+          A code goes stale on its own after a while, and the poll cannot always
+          say so — the session may simply stop answering — which left the window
+          showing a QR that looked fine and could not be scanned, with no way to
+          ask for another. The old client kept this button visible too. */}
+      <button
+        type="button"
+        onClick={handleRefresh}
+        disabled={status === "loading"}
+        className={`mt-4 w-full rounded-lg px-4 py-2.5 text-[12px] font-semibold tracking-[1.5px] uppercase transition-opacity ${
+          status === "expired" || status === "error"
+            ? "bg-accent text-[var(--on-accent)] hover:opacity-90"
+            : "border border-border bg-transparent text-text-dim hover:border-accent hover:text-accent"
+        } disabled:cursor-default disabled:opacity-40`}
+      >
+        {t("login.qr.refresh")}
+      </button>
 
       <button
         type="button"

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -218,6 +218,16 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
     return stopPolling;
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // The window is sized for the form this view replaces, which is shorter than
+  // it — so it is asked for the right height on the way in rather than left to
+  // whatever the previous page needed, and given back on the way out.
+  useEffect(() => {
+    commands.resizeWindow("login-qr").catch(() => {});
+    return () => {
+      commands.resizeWindow("login").catch(() => {});
+    };
+  }, []);
+
   // The clock, ticking off the issue time rather than off a counter, so leaving
   // the view and coming back shows what is actually left rather than restarting
   // at three minutes.
@@ -398,7 +408,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
                     commands.resizeWindow("login-enlarged").catch(() => {});
                     setEnlarged(true);
                   } else {
-                    commands.resizeWindow("login").catch(() => {});
+                    commands.resizeWindow("login-qr").catch(() => {});
                     setEnlarged(false);
                   }
                 }

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -47,6 +47,17 @@ const POLL_LIFETIME_MS = 5 * 60 * 1000;
  */
 const QR_LIFETIME_MS = 3 * 60 * 1000;
 
+/**
+ * How much of beanfun's quiet zone to crop away.
+ *
+ * Their PNG carries far more white around the code than the standard's four
+ * modules, and that white scales with the image — so a bigger code is a bigger
+ * margin, not a fuller one. Clipping 6.5% from each edge leaves well over the
+ * required quiet zone on every code size seen, and is the only thing that
+ * changes the proportion rather than the size.
+ */
+const QR_ZOOM = 1.15;
+
 /** `m:ss`, or `0:00` once there is nothing left. */
 function asClock(ms: number): string {
   const total = Math.max(0, Math.ceil(ms / 1000));
@@ -236,8 +247,12 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
   // (still comfortably scannable; "enlarge" is a click away).
   const compact = useConfigStore((s) => s.config?.compactUi ?? false);
   const expired = status === "expired" || status === "error";
-  const qrBox = enlarged ? "p-4" : compact ? "h-[172px] w-[172px] p-2" : "h-[228px] w-[228px] p-2";
-  const qrPx = enlarged ? 396 : compact ? 156 : 212;
+  const qrBox = enlarged
+    ? "p-4"
+    : compact
+      ? "h-[172px] w-[172px] p-2.5"
+      : "h-[228px] w-[228px] p-3";
+  const qrPx = enlarged ? 392 : compact ? 152 : 204;
 
   return (
     <div className="flex w-full flex-col items-center">
@@ -269,16 +284,29 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
           {status === "loading" ? (
             <div className="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
           ) : qrData?.qrImageUrl ? (
-            <img
-              src={qrData.qrImageUrl}
-              alt="QR Code"
-              className={`block rounded transition-all ${expired ? "opacity-25 blur-[2px]" : ""}`}
-              style={{
-                width: qrPx,
-                height: qrPx,
-                imageRendering: "pixelated",
-              }}
-            />
+            <div
+              className="overflow-hidden rounded"
+              style={{ width: qrPx, height: qrPx }}
+              aria-hidden={false}
+            >
+              <img
+                src={qrData.qrImageUrl}
+                alt="QR Code"
+                className={`block transition-all ${expired ? "opacity-25 blur-[2px]" : ""}`}
+                style={{
+                  width: qrPx,
+                  height: qrPx,
+                  // Scaled inside a clipped box rather than made larger: most of
+                  // the white is beanfun's own quiet zone, which grows with the
+                  // image, so enlarging changes nothing about the proportion.
+                  // The standard asks for four modules of quiet zone and this
+                  // leaves far more than that — the crop only takes back what
+                  // was spare.
+                  transform: `scale(${QR_ZOOM})`,
+                  imageRendering: "pixelated",
+                }}
+              />
+            </div>
           ) : (
             <div className="text-xs text-text-faint">—</div>
           )}
@@ -441,24 +469,28 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
           </div>
         )}
 
-        {!enlarged && (
-          <div className="flex flex-col items-center gap-0.5">
-            <div className="animate-pulse text-[12px] tracking-[1px] text-text-dim">
-              {status === "expired"
-                ? t("login.qr.expired")
-                : status === "error"
-                  ? (error ?? "Error")
-                  : t("login.qr.waiting")}
-            </div>
-            {/* Steady, unlike the line above it: a clock that fades in and out
-                is harder to read than one that does not. */}
-            {status === "pending" && remaining !== null && remaining > 0 && (
-              <div className="text-[11px] tracking-[0.5px] text-text-faint tabular-nums">
-                {t("login.qr.valid_for")}: {asClock(remaining)}
-              </div>
-            )}
+        {/* One typographic block, not two lines that happen to sit together: a
+            different size or letter-spacing on each shifts their optical centres
+            apart, and centred text then reads as misaligned.
+
+            Shown when enlarged too — the code is what the enlarged view is for,
+            and hiding how long it has left was the one thing worth knowing. */}
+        <div className="flex flex-col items-center gap-0.5 text-[12px] tracking-[1px] text-text-dim">
+          <div className="animate-pulse">
+            {status === "expired"
+              ? t("login.qr.expired")
+              : status === "error"
+                ? (error ?? "Error")
+                : t("login.qr.waiting")}
           </div>
-        )}
+          {/* Steady, unlike the line above it: a clock that fades in and out
+                is harder to read than one that does not. */}
+          {status === "pending" && remaining !== null && remaining > 0 && (
+            <div className="text-text-faint tabular-nums">
+              {t("login.qr.valid_for")}: {asClock(remaining)}
+            </div>
+          )}
+        </div>
       </div>
 
       <button

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -236,8 +236,8 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
   // (still comfortably scannable; "enlarge" is a click away).
   const compact = useConfigStore((s) => s.config?.compactUi ?? false);
   const expired = status === "expired" || status === "error";
-  const qrBox = enlarged ? "p-5" : compact ? "h-[172px] w-[172px] p-3" : "h-[228px] w-[228px] p-4";
-  const qrPx = enlarged ? 380 : compact ? 148 : 196;
+  const qrBox = enlarged ? "p-4" : compact ? "h-[172px] w-[172px] p-2" : "h-[228px] w-[228px] p-2";
+  const qrPx = enlarged ? 396 : compact ? 156 : 212;
 
   return (
     <div className="flex w-full flex-col items-center">
@@ -442,21 +442,21 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
         )}
 
         {!enlarged && (
-          {/* The pulse is there to say "still working" while nothing else
-              moves. A ticking clock already says that, and digits that fade in
-              and out are harder to read than digits that don't. */}
-          <div
-            className={`text-[12px] tracking-[1px] text-text-dim ${
-              remaining !== null && remaining > 0 && status === "pending" ? "" : "animate-pulse"
-            }`}
-          >
-            {status === "expired"
-              ? t("login.qr.expired")
-              : status === "error"
-                ? (error ?? "Error")
-                : remaining !== null && remaining > 0
-                  ? `${t("login.qr.waiting")}  ${asClock(remaining)}`
+          <div className="flex flex-col items-center gap-0.5">
+            <div className="animate-pulse text-[12px] tracking-[1px] text-text-dim">
+              {status === "expired"
+                ? t("login.qr.expired")
+                : status === "error"
+                  ? (error ?? "Error")
                   : t("login.qr.waiting")}
+            </div>
+            {/* Steady, unlike the line above it: a clock that fades in and out
+                is harder to read than one that does not. */}
+            {status === "pending" && remaining !== null && remaining > 0 && (
+              <div className="text-[11px] tracking-[0.5px] text-text-faint tabular-nums">
+                {t("login.qr.valid_for")}: {asClock(remaining)}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -29,6 +29,15 @@ function pngFromDataUrl(url: string): Blob | null {
   }
 }
 
+/**
+ * How long to keep asking whether a code has been scanned.
+ *
+ * Generous — a real code expires well before this — because the cost of being
+ * wrong is one press of a refresh button that is now always on screen, while
+ * the cost of no limit at all is an open window polling beanfun forever.
+ */
+const POLL_LIFETIME_MS = 10 * 60 * 1000;
+
 interface QrLoginFormProps {
   onBack: () => void;
 }
@@ -61,7 +70,20 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
   function startPolling(sessionId: string, data: QrCodeData) {
     stopPolling();
     failures.current = 0;
+    const startedAt = Date.now();
     intervalRef.current = setInterval(async () => {
+      // A code does not live this long, and asking after it does is not free:
+      // every two seconds is thirty requests a minute to beanfun, and a window
+      // left open all afternoon was sending thousands. That is a plausible way
+      // to end up throttled — which would also explain normal login failing
+      // afterwards, since it reaches the same host, and throttling follows the
+      // address rather than the session.
+      if (Date.now() - startedAt > POLL_LIFETIME_MS) {
+        stopPolling();
+        setStatus("expired");
+        useUiStore.setState({ qrSessionId: null, qrData: null });
+        return;
+      }
       try {
         const result: QrPollResult = await commands.qrLoginPoll(
           sessionId,

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -32,11 +32,12 @@ function pngFromDataUrl(url: string): Blob | null {
 /**
  * How long to keep asking whether a code has been scanned.
  *
- * Generous — a real code expires well before this — because the cost of being
- * wrong is one press of a refresh button that is now always on screen, while
- * the cost of no limit at all is an open window polling beanfun forever.
+ * A code lasts three minutes — measured, not guessed: issued 04:42:03, refused
+ * at 04:45:03 — and beanfun says so itself, answering `Token Expired`, which is
+ * what normally ends the polling. This is the backstop for the case where that
+ * answer never arrives, with enough headroom that it never fires first.
  */
-const POLL_LIFETIME_MS = 10 * 60 * 1000;
+const POLL_LIFETIME_MS = 5 * 60 * 1000;
 
 interface QrLoginFormProps {
   onBack: () => void;
@@ -72,12 +73,10 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
     failures.current = 0;
     const startedAt = Date.now();
     intervalRef.current = setInterval(async () => {
-      // A code does not live this long, and asking after it does is not free:
-      // every two seconds is thirty requests a minute to beanfun, and a window
-      // left open all afternoon was sending thousands. That is a plausible way
-      // to end up throttled — which would also explain normal login failing
-      // afterwards, since it reaches the same host, and throttling follows the
-      // address rather than the session.
+      // Normally unreachable: beanfun answers `Token Expired` at three minutes
+      // and the poll stops there. This catches the case where it never says so
+      // — a request that keeps failing, or an answer that never comes — which
+      // would otherwise leave this running for as long as the window is open.
       if (Date.now() - startedAt > POLL_LIFETIME_MS) {
         stopPolling();
         setStatus("expired");
@@ -194,6 +193,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
   // Compact UI: the shorter window drops the logo and shows a smaller code
   // (still comfortably scannable; "enlarge" is a click away).
   const compact = useConfigStore((s) => s.config?.compactUi ?? false);
+  const expired = status === "expired" || status === "error";
   const qrBox = enlarged ? "p-5" : compact ? "h-[172px] w-[172px] p-3" : "h-[228px] w-[228px] p-4";
   const qrPx = enlarged ? 380 : compact ? 148 : 196;
 
@@ -222,7 +222,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
         className={`flex w-full flex-col items-center gap-3 rounded-[14px] border border-border bg-[var(--surface)] ${compact ? "p-3" : "p-5"}`}
       >
         <div
-          className={`flex items-center justify-center rounded-xl bg-white shadow-[0_2px_12px_rgba(0,0,0,0.08)] ${qrBox}`}
+          className={`relative flex items-center justify-center rounded-xl bg-white shadow-[0_2px_12px_rgba(0,0,0,0.08)] ${qrBox}`}
         >
           {status === "loading" ? (
             <div className="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
@@ -230,7 +230,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
             <img
               src={qrData.qrImageUrl}
               alt="QR Code"
-              className="block rounded"
+              className={`block rounded transition-all ${expired ? "opacity-25 blur-[2px]" : ""}`}
               style={{
                 width: qrPx,
                 height: qrPx,
@@ -239,6 +239,27 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
             />
           ) : (
             <div className="text-xs text-text-faint">—</div>
+          )}
+
+          {/* An expired code is answered where it is, rather than by a button
+              further down the window — which is also how the old client did it,
+              and which stops the layout growing a row it did not have. */}
+          {expired && (
+            <button
+              type="button"
+              onClick={handleRefresh}
+              title={t("login.qr.refresh")}
+              className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-xl"
+            >
+              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-accent text-[var(--on-accent)] shadow-md transition-transform hover:scale-105">
+                <svg width="26" height="26" viewBox="0 0 44 44" fill="currentColor">
+                  <path d="M32.4,11.6C29.7,9,26.1,7.3,22,7.3C13.9,7.3,7.4,13.9,7.4,22c0,8.1,6.5,14.7,14.6,14.7 c6.8,0,12.5-4.7,14.2-11h-3.8C30.9,29.9,26.8,33,22,33c-6.1,0-11-4.9-11-11c0-6.1,4.9-11,11-11c3,0,5.8,1.3,7.7,3.3l-5.9,5.9h12.8 V7.3L32.4,11.6z" />
+                </svg>
+              </span>
+              <span className="text-[11px] font-semibold text-[#555]">
+                {t("login.qr.expired_short")}
+              </span>
+            </button>
           )}
         </div>
 
@@ -388,24 +409,6 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
           </div>
         )}
       </div>
-
-      {/* Always offered, not only once the poll has noticed the code is dead.
-          A code goes stale on its own after a while, and the poll cannot always
-          say so — the session may simply stop answering — which left the window
-          showing a QR that looked fine and could not be scanned, with no way to
-          ask for another. The old client kept this button visible too. */}
-      <button
-        type="button"
-        onClick={handleRefresh}
-        disabled={status === "loading"}
-        className={`mt-4 w-full rounded-lg px-4 py-2.5 text-[12px] font-semibold tracking-[1.5px] uppercase transition-opacity ${
-          status === "expired" || status === "error"
-            ? "bg-accent text-[var(--on-accent)] hover:opacity-90"
-            : "border border-border bg-transparent text-text-dim hover:border-accent hover:text-accent"
-        } disabled:cursor-default disabled:opacity-40`}
-      >
-        {t("login.qr.refresh")}
-      </button>
 
       <button
         type="button"

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -39,6 +39,20 @@ function pngFromDataUrl(url: string): Blob | null {
  */
 const POLL_LIFETIME_MS = 5 * 60 * 1000;
 
+/**
+ * How long a code is good for. Measured, not guessed: issued 04:42:03, refused
+ * at 04:45:03. beanfun says so itself by answering `Token Expired`, and the two
+ * agree — this is what lets the window count down rather than only find out
+ * afterwards.
+ */
+const QR_LIFETIME_MS = 3 * 60 * 1000;
+
+/** `m:ss`, or `0:00` once there is nothing left. */
+function asClock(ms: number): string {
+  const total = Math.max(0, Math.ceil(ms / 1000));
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+}
+
 interface QrLoginFormProps {
   onBack: () => void;
 }
@@ -59,6 +73,8 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
   const startedRef = useRef(false);
   /** Consecutive failed polls, to tell a blink apart from a dead session. */
   const failures = useRef(0);
+  /** Milliseconds left on the current code, or null when there isn't one. */
+  const [remaining, setRemaining] = useState<number | null>(null);
   const sessionIdRef = useRef<string | null>(useUiStore.getState().qrSessionId);
 
   function stopPolling() {
@@ -80,7 +96,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
       if (Date.now() - startedAt > POLL_LIFETIME_MS) {
         stopPolling();
         setStatus("expired");
-        useUiStore.setState({ qrSessionId: null, qrData: null });
+        useUiStore.setState({ qrSessionId: null, qrData: null, qrIssuedAt: null });
         return;
       }
       try {
@@ -106,6 +122,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
             useUiStore.setState({
               qrSessionId: null,
               qrData: null,
+              qrIssuedAt: null,
               loginView: "normal",
               addingSession: false,
             });
@@ -117,7 +134,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
         } else if (result.status === "expired") {
           stopPolling();
           setStatus("expired");
-          useUiStore.setState({ qrSessionId: null, qrData: null });
+          useUiStore.setState({ qrSessionId: null, qrData: null, qrIssuedAt: null });
         }
         failures.current = 0;
       } catch {
@@ -128,7 +145,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
         if (failures.current >= 5) {
           stopPolling();
           setStatus("expired");
-          useUiStore.setState({ qrSessionId: null, qrData: null });
+          useUiStore.setState({ qrSessionId: null, qrData: null, qrIssuedAt: null });
         }
       }
     }, 2000);
@@ -159,7 +176,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
       setStatus("pending");
 
       // Persist for session resume
-      useUiStore.setState({ qrSessionId: sessionId, qrData: data });
+      useUiStore.setState({ qrSessionId: sessionId, qrData: data, qrIssuedAt: Date.now() });
 
       startPolling(sessionId, data);
     } catch (err) {
@@ -179,7 +196,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
     // Cleared, not just replaced: if the new code never arrives, the old one
     // must not sit there next to an error message looking scannable.
     setQrData(null);
-    useUiStore.setState({ qrSessionId: null, qrData: null });
+    useUiStore.setState({ qrSessionId: null, qrData: null, qrIssuedAt: null });
     startedRef.current = false;
     startQr();
   }
@@ -189,6 +206,31 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
     startQr();
     return stopPolling;
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // The clock, ticking off the issue time rather than off a counter, so leaving
+  // the view and coming back shows what is actually left rather than restarting
+  // at three minutes.
+  useEffect(() => {
+    const tick = () => {
+      const issuedAt = useUiStore.getState().qrIssuedAt;
+      if (issuedAt === null) {
+        setRemaining(null);
+        return;
+      }
+      const left = issuedAt + QR_LIFETIME_MS - Date.now();
+      setRemaining(left);
+      // Said here as well as by the server: beanfun answers `Token Expired` at
+      // the same moment, but only when asked, and the window should not show a
+      // live-looking code for the two seconds until the next poll.
+      if (left <= 0) {
+        stopPolling();
+        setStatus("expired");
+      }
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [status, qrData]);
 
   // Compact UI: the shorter window drops the logo and shows a smaller code
   // (still comfortably scannable; "enlarge" is a click away).
@@ -400,12 +442,21 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
         )}
 
         {!enlarged && (
-          <div className="animate-pulse text-[12px] tracking-[1px] text-text-dim">
+          {/* The pulse is there to say "still working" while nothing else
+              moves. A ticking clock already says that, and digits that fade in
+              and out are harder to read than digits that don't. */}
+          <div
+            className={`text-[12px] tracking-[1px] text-text-dim ${
+              remaining !== null && remaining > 0 && status === "pending" ? "" : "animate-pulse"
+            }`}
+          >
             {status === "expired"
               ? t("login.qr.expired")
               : status === "error"
                 ? (error ?? "Error")
-                : t("login.qr.waiting")}
+                : remaining !== null && remaining > 0
+                  ? `${t("login.qr.waiting")}  ${asClock(remaining)}`
+                  : t("login.qr.waiting")}
           </div>
         )}
       </div>

--- a/src/lib/stores/ui-store.ts
+++ b/src/lib/stores/ui-store.ts
@@ -54,6 +54,12 @@ export interface UiState {
   /** Persisted QR login state so it survives qr-viewer round-trip. */
   qrSessionId: string | null;
   qrData: { sessionKey: string; qrImageUrl: string; verificationToken: string } | null;
+  /**
+   * When the current code was issued, so the countdown survives leaving the QR
+   * view and coming back — without it, a code with thirty seconds left would
+   * come back showing a fresh three minutes.
+   */
+  qrIssuedAt: number | null;
   setPage: (page: Page) => void;
   goBack: () => void;
   setTheme: (theme: ThemeMode) => void;
@@ -81,6 +87,7 @@ export const useUiStore = create<UiState>((set, get) => ({
   loginView: "",
   qrSessionId: null,
   qrData: null,
+  qrIssuedAt: null,
   setPage: (page) => {
     const current = get().currentPage;
     // Remember a non-overlay page so goBack() returns to it from toolbox/web_launch.

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -69,6 +69,7 @@
   "login.qr.scanned": "Scanned, confirming...",
   "login.qr.expired": "QR code expired. Please refresh.",
   "login.qr.refresh": "Refresh QR Code",
+  "login.qr.valid_for": "Valid for",
   "login.qr.expired_short": "Expired",
   "login.qr.copy": "Copy QR",
   "login.qr.enlarge": "Enlarge",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -69,6 +69,7 @@
   "login.qr.scanned": "Scanned, confirming...",
   "login.qr.expired": "QR code expired. Please refresh.",
   "login.qr.refresh": "Refresh QR Code",
+  "login.qr.expired_short": "Expired",
   "login.qr.copy": "Copy QR",
   "login.qr.enlarge": "Enlarge",
   "login.qr.copy_deeplink": "Copy Link",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -45,6 +45,7 @@
   "login.classic_pick_account_hint": "This GamaPass account has more than one game account. Pick the one to sign in to Classic with.",
   "login.username": "Username",
   "login.password": "Password",
+  "login.error.required": "Please enter your {{field}}",
   "login.username_placeholder": "Enter your username",
   "login.password_placeholder": "Enter your password",
   "login.submit": "Sign In",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -69,6 +69,7 @@
   "login.qr.scanned": "已扫描，确认中...",
   "login.qr.expired": "QR Code 已过期，请刷新。",
   "login.qr.refresh": "刷新 QR Code",
+  "login.qr.expired_short": "已过期",
   "login.qr.copy": "复制 QR",
   "login.qr.enlarge": "放大",
   "login.qr.copy_deeplink": "复制链接",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -69,6 +69,7 @@
   "login.qr.scanned": "已扫描，确认中...",
   "login.qr.expired": "QR Code 已过期，请刷新。",
   "login.qr.refresh": "刷新 QR Code",
+  "login.qr.valid_for": "有效期",
   "login.qr.expired_short": "已过期",
   "login.qr.copy": "复制 QR",
   "login.qr.enlarge": "放大",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -45,6 +45,7 @@
   "login.classic_pick_account_hint": "此 GamaPass 账号下有多个游戏账号，请选择要用来登录经典版的一个。",
   "login.username": "账号",
   "login.password": "密码",
+  "login.error.required": "请输入{{field}}",
   "login.username_placeholder": "输入你的账号",
   "login.password_placeholder": "输入你的密码",
   "login.submit": "登录",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -45,6 +45,7 @@
   "login.classic_pick_account_hint": "此 GamaPass 帳號下有多個遊戲帳號，請選擇要用來登入經典版的一個。",
   "login.username": "帳號",
   "login.password": "密碼",
+  "login.error.required": "請輸入{{field}}",
   "login.username_placeholder": "輸入你的帳號",
   "login.password_placeholder": "輸入你的密碼",
   "login.submit": "登入",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -69,6 +69,7 @@
   "login.qr.scanned": "已掃描，確認中...",
   "login.qr.expired": "QR Code 已過期，請重新整理。",
   "login.qr.refresh": "重新整理 QR Code",
+  "login.qr.expired_short": "已過期",
   "login.qr.copy": "複製 QR",
   "login.qr.enlarge": "放大",
   "login.qr.copy_deeplink": "複製連結",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -69,6 +69,7 @@
   "login.qr.scanned": "已掃描，確認中...",
   "login.qr.expired": "QR Code 已過期，請重新整理。",
   "login.qr.refresh": "重新整理 QR Code",
+  "login.qr.valid_for": "有效期",
   "login.qr.expired_short": "已過期",
   "login.qr.copy": "複製 QR",
   "login.qr.enlarge": "放大",


### PR DESCRIPTION
Reported: the QR can't be refreshed, and the copy-image button does nothing.

- **Refresh** only appeared once the poll declared the code expired, and the poll couldn't always tell — failures were swallowed and retried forever. Now it's the beanfun reload glyph over the dimmed code, the way their site does it, and five failed polls say expired instead of pretending.
- **Copy image** awaited a `fetch` before `clipboard.write`, which spends the click's user activation and makes Chromium refuse. Decoded from base64 synchronously instead. The error was also swallowed, which is why it looked like nothing happened.
- **Countdown** — a code lasts 3 minutes (measured: issued 04:42:03, refused 04:45:03). Shown on its own line, counted from when it was issued so leaving and returning shows what's actually left.
- **Window size** — the QR view was borrowing the login form's height and the countdown pushed compact past 490px, so it scrolled and the back button sat on the status line. It has its own size now, asked for on entry.
- **QR size** — most of the white was beanfun's own quiet zone, which scales with the image; cropped 6.5% per edge, well clear of the 4 modules the standard needs.
- **Silent login** — `handleSubmit` returned without a word on an empty field. A debug log of "QR then back to normal login fails" showed the attempt never reaching the backend at all, and this is the only path that ends that way. It now names the field and writes a log line.

## Not solved

Why the field was empty. `get_last_saved_account` does return the password, so it should have been filled. The log line added here will say, next time it happens.