### PR TITLE
fix(autopaste): let focus settle after tab, so the otp stops landing in the account field

### DIFF
--- a/src-tauri/src/services/autopaste_service.rs
+++ b/src-tauri/src/services/autopaste_service.rs
@@ -141,6 +141,22 @@ mod win32 {
         }
     }
 
+    /// How long to wait after TAB before posting anything else.
+    ///
+    /// `clear_field` already explains why posted input needs a pause: a game
+    /// that samples input per frame does not consume the queue in one go. TAB
+    /// is worse, because what it changes is focus, and that lands at the end of
+    /// the frame that read it — anything posted in the same batch still goes to
+    /// the field we were trying to leave.
+    ///
+    /// Without this pause the backspaces meant for the password field eat the
+    /// account instead, and the OTP is appended to whatever survived: both
+    /// values in one box. That is exactly how this was reported, and it stayed
+    /// reproducible across releases for the people it happened to, because
+    /// nothing about it depends on the version — only on how fast the machine
+    /// gets round to the message queue.
+    const FOCUS_SETTLE_MS: u64 = 100;
+
     /// Sleep for the given number of milliseconds (sync, NOT tokio).
     fn sleep_ms(ms: u64) {
         std::thread::sleep(std::time::Duration::from_millis(ms));
@@ -149,12 +165,13 @@ mod win32 {
     /// Main auto-paste implementation.
     /// Auto-paste credentials into MapleStory window (HK + TW 統一版)
     ///
-    /// Timing matches the original C# Beanfun implementation:
+    /// Timing:
     /// - SetForegroundWindow → 100ms
     /// - ESC → 100ms
     /// - Click account field → 200ms
-    /// - All PostMessage calls (keys, chars) are fire-and-forget with no
-    ///   per-character delay, since PostMessage queues messages asynchronously.
+    /// - TAB to the password field → 100ms (see FOCUS_SETTLE_MS)
+    /// - Characters carry no per-character delay: PostMessage queues them and
+    ///   the game reads them in order.
     pub fn do_auto_paste(account_id: &str, otp: &str) -> bool {
         let hwnd = match find_maple_window() {
             Some(h) => h,
@@ -215,12 +232,14 @@ mod win32 {
         }
 
         // ==================== 通用步驟 (HK + TW 都一樣) ====================
-        // Original C# fires all PostMessage calls with no inter-step delays.
-        // PostMessage is async — messages queue in the target window's message
-        // loop and are processed in order, so no sleeps needed.
+        // The original C# fires these with no inter-step delays, and ordering
+        // alone is enough for anything that only writes characters: PostMessage
+        // queues them and the game reads them in order. Focus is the exception —
+        // see FOCUS_SETTLE_MS.
         clear_field(hwnd, 64); // 清空帳號欄
         type_string(hwnd, account_id); // 輸入帳號
         send_key(hwnd, VK_TAB); // 切換到密碼欄
+        sleep_ms(FOCUS_SETTLE_MS); // 等焦點真的移過去，見 FOCUS_SETTLE_MS
         clear_field(hwnd, 20); // 清空密碼欄
         type_string(hwnd, otp); // 輸入密碼
         send_key(hwnd, VK_RETURN); // 按登入


### PR DESCRIPTION
## What

Wait 100ms after the TAB that moves auto-paste from the account field to the
password field, before posting anything else.

## Why

Reported by a user whose account and OTP always land concatenated in one field,
across many releases.

`PostMessage` keeps its ordering, which is enough for anything that only writes
characters. Focus is the exception: a game that samples input per frame applies
the focus change at the end of the frame that read it, so the END and 20
backspaces posted straight after the TAB still go to the account field. They eat
the account, the OTP is appended to what survived, and both values end up in one
box.

`clear_field` already had a pause for the same reason, with a comment explaining
it — the reasoning had been applied to the backspaces but not to the TAB.

Nothing here depends on the version, only on how quickly a machine gets to the
message queue, which is why updating never changed it for the people affected
and why most people never see it.

This is a timing fix, not a guarantee. If it still happens, the next step is
clicking the password field directly rather than relying on TAB — not a longer
wait.

## How to test

Needs a machine that reproduces it; the reporter is the one who can confirm.

1. Log in, get an OTP with auto-paste enabled and the game at its login screen.
2. Account goes in the account field, OTP in the password field, login submits.

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes
- [ ] Tested locally with `cargo tauri dev` — needs the game client and a machine that reproduces it
- [x] No breaking changes to existing features
