### PR TITLE
harden(webview): stop turning off the renderer sandbox

### DIFF
--- a/src-tauri/src/services/browser_window.rs
+++ b/src-tauri/src/services/browser_window.rs
@@ -27,12 +27,16 @@
 //! or redirected to — is handed to the user's own browser instead.
 //!
 //! Cookies alone would not have needed that: they are scoped by domain, so the
-//! session never reaches a third party. The renderer is the reason. Every
-//! WebView2 this app opens runs with `--no-sandbox`, and the app self-elevates,
-//! so a renderer here is an unsandboxed one holding an administrator token. That
-//! was a contained risk while these windows only ever showed beanfun. An address
-//! bar would have turned it into "any site the user can be talked into typing",
-//! which is a different thing entirely.
+//! session never reaches a third party. The renderer is the reason. This process
+//! self-elevates, so a page loaded here is rendered by a process holding an
+//! administrator token, and a sandbox escape lands on a machine rather than in a
+//! browser profile. That was a contained risk while these windows only ever
+//! showed beanfun. An address bar would have turned it into "any site the user
+//! can be talked into typing", which is a different thing entirely.
+//!
+//! (Until `webview_util::browser_args` dropped `--no-sandbox`, there was no
+//! sandbox to escape from. That is fixed; the elevation is not, and it is
+//! enough on its own to keep this window where it is.)
 //!
 //! Downloads are refused for the same reason: anything this process launches
 //! inherits its token, and this window exists for reading event pages.

--- a/src-tauri/src/services/webview_util.rs
+++ b/src-tauri/src/services/webview_util.rs
@@ -9,10 +9,23 @@ pub const WEBVIEW_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) 
 /// its traffic leaves through this process — see `services::local_proxy` for why
 /// that matters to accelerator users. Loopback is excluded from the proxy, or it
 /// would be asked to reach itself.
+///
+/// ## What is not here any more
+///
+/// `--no-sandbox` used to be. It turns off the thing that keeps a compromised
+/// renderer away from the rest of the machine, and this process self-elevates,
+/// so every page we loaded ran unsandboxed holding an administrator token.
+///
+/// It arrived in the initial commit with no message, no comment and no issue
+/// behind it, which is not evidence either way. What settled it is Beanfun: it
+/// passes WebView2 nothing but the Edge feature disables and an autoplay
+/// policy, and it serves the same beanfun pages, the same TW login and
+/// reCAPTCHA, to the same players running the same accelerators. The flag is
+/// not load-bearing for this workload.
 pub async fn browser_args(app: &tauri::AppHandle) -> String {
     use tauri::Manager;
 
-    const BASE: &str = "--disable-blink-features=AutomationControlled --no-sandbox";
+    const BASE: &str = "--disable-blink-features=AutomationControlled";
 
     let wanted = match app.try_state::<crate::models::app_state::AppState>() {
         Some(state) => state.config.read().await.webview_via_proxy,


### PR DESCRIPTION
## What

Drop `--no-sandbox` from the browser arguments every WebView2 window is opened with. `--disable-blink-features=AutomationControlled` stays.

## Why

It turns off the thing that keeps a compromised renderer away from the rest of the machine, and this process self-elevates, so every page we loaded ran unsandboxed holding an administrator token.

It arrived in the initial commit with no message, no comment and no issue behind it — which is not evidence either way. What settles it is Beanfun: it passes WebView2 nothing but the Edge feature disables and an autoplay policy, and it serves the same beanfun pages, the same TW login and reCAPTCHA, to the same players running the same accelerators. The flag is not load-bearing for this workload.

The in-app browser's module docs claimed the missing sandbox as part of why that window is scope-limited; corrected, since the elevation alone is enough to justify it.

## How to test

The flag is shared by every webview, so this needs the whole set — and an accelerator running, which is the case that would have justified the flag if anything did:

1. TW id/password login (the reCAPTCHA helper window)
2. TW QR login
3. GamaPass login
4. Classic portal
5. Top-up window
6. Beanfun browser
7. All of the above again with an accelerator running

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes
- [ ] Tested locally with `cargo tauri dev` — windows open; the login flows above need real accounts and an accelerator
- [x] No breaking changes to existing features
