### PR TITLE
chore(release): make the release notes bilingual throughout, and stop them contradicting each other

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,36 +270,40 @@ jobs:
                 || format('v{0}', steps.version.outputs.version)
             }}
           body: |
-            **Version:** v${{ steps.version.outputs.version }}
-            **Type:** ${{ github.event.inputs.release_type == 'release' && 'Release' || 'Pre-Release' }}
-            **Built:** ${{ steps.version.outputs.build_time }} UTC
+            **版本 / Version:** v${{ steps.version.outputs.version }}
+            **類型 / Type:** ${{ github.event.inputs.release_type == 'release' && '正式版 / Release' || '預先發佈 / Pre-Release' }}
+            **建置時間 / Built:** ${{ steps.version.outputs.build_time }} UTC
 
             ---
 
-            ### Download
-            **新用户（推荐 / New users）→ [MapleLink-Setup.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag_name }}/MapleLink-Setup.exe)** — 自解压包，附「WebView2 报错看这」说明 / self-extracting package with a WebView2 troubleshooting note
+            ### 下載 / Download
 
-            **[MapleLink.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag_name }}/MapleLink.exe)** — 单文件绿色版 / standalone, no installation needed
+            **[MapleLink-Setup.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag_name }}/MapleLink-Setup.exe)** — 新使用者建議下載這個。自解壓縮，內附「webview2報錯看這.txt」。
+            Recommended for new users. Self-extracting, with a note on the WebView2 error inside.
 
-            ### Changes
+            **[MapleLink.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag_name }}/MapleLink.exe)** — 程式本身，免安裝。自動更新更新的就是這個檔案。
+            The program on its own, nothing to install. This is the file auto-update replaces.
+
+            ### 使用方式 / Usage
+
+            1. 下載上面任一個檔案 / Download either file above
+            2. 放到任何資料夾直接執行 / Put it in any folder and run it
+            3. 首次啟動會自動解壓地區模擬檔案 / The first launch unpacks the locale-emulation files
+
+            ### 變更 / Changes
             ${{ steps.notes.outputs.commits }}
 
             (${{ steps.notes.outputs.count }} commits)
 
-            ### Usage
-            1. Download **MapleLink.exe**
-            2. Place in any folder and run
-            3. First launch will auto-extract locale emulation files
-
-            ${{ github.event.inputs.release_type == 'prerelease' && '> ⚠️ This is a pre-release. Use at your own risk.' || '' }}
+            ${{ github.event.inputs.release_type == 'prerelease' && '> ⚠️ 這是預先發佈版本，請自行評估風險。 / This is a pre-release. Use at your own risk.' || '' }}
 
             <details>
-            <summary>Details</summary>
+            <summary>詳細資訊 / Details</summary>
 
-            | Item | Value |
+            | 項目 / Item | 內容 / Value |
             |------|-------|
             | SHA256 | `${{ steps.artifact.outputs.sha256 }}` |
-            | Build Time | ${{ steps.version.outputs.build_time }} UTC |
+            | 建置時間 / Build time | ${{ steps.version.outputs.build_time }} UTC |
             | Commit | [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}) |
 
             </details>


### PR DESCRIPTION
## What

The generated release body is Traditional Chinese + English throughout, instead of English everywhere except two Simplified Chinese lines.

Three things were wrong beyond the language mix:

- **The Download and Usage sections disagreed.** Download told new users to take `MapleLink-Setup.exe`; Usage then said "1. Download **MapleLink.exe**". Someone following the recommendation read instructions for the other file. Usage now says either file.
- **The bundled note was quoted under a name it does not have.** The release body said `「WebView2 报错看这」`; the file is `installer/webview2報錯看這.txt`, Traditional. Quoted exactly now, extension included, since the point of quoting it is that someone can find it after extracting.
- **`MapleLink.exe` was labelled `单文件绿色版`.** Accurate but jargon, and it left out the thing worth knowing: this is the file auto-update replaces.

## Why

Everything else in the repo is Traditional — the bundled note, the extracted folder name (`MapleLink登陸器`), the README, the app's lead locale. Only the release notes had drifted to Simplified, and only for two lines out of a page that was otherwise English.

Bilingual rather than English-only because the audience reads Chinese: an English-only release page served them two lines out of the whole thing.

## How to test

The workflow still parses (`yaml.safe_load`). The body is only rendered by a real release run, so the next release is the check — the substitutions are unchanged, only the prose around them.

## Checklist

- [x] `cargo clippy -- -D warnings` passes (no Rust changes)
- [x] `npm run lint` passes (no frontend changes)
- [ ] Tested locally with `cargo tauri dev` — not applicable; CI-only change, verified by parsing the workflow
- [x] No breaking changes to existing features
