### PR TITLE
fix(site): region toggle in demos shows HK/TW as text

### DIFF
--- a/site/src/demo/UiTitlebar.tsx
+++ b/site/src/demo/UiTitlebar.tsx
@@ -32,7 +32,9 @@ export default function UiTitlebar({
             🍁{classic && <i className={styles.under} />}
           </button>
           <button className={clsx(styles.btn, hint === "region" && "ml-hint")} title={t("切換地區", "切换地区", "Toggle region")} onClick={onToggleRegion}>
-            {region === "TW" ? "🇹🇼" : "🇭🇰"}
+            {/* The app uses flag emoji here; Windows has no flag glyphs and draws
+                the letters instead, which is what players actually see. */}
+            {region}
             {!classic && <i className={styles.under} />}
           </button>
         </>


### PR DESCRIPTION
## What

- The demo title bar showed the region as flag emoji. Windows has no flag glyphs and renders the letters, so the demos now show `HK` / `TW` as text, matching what players see.

## Why

The demos must look like the real app on Windows.

## How to test

- `cd site && npm run build && npm run serve`, open the guide, check the sign-in demo title bar reads `HK` and flips to `TW`.

## Checklist

- [ ] `cargo clippy -- -D warnings` passes (not applicable)
- [ ] `npm run lint` passes (not applicable)
- [ ] Tested locally with `cargo tauri dev` (not applicable)
- [x] No breaking changes to existing features
