### PR TITLE
docs: link the official website, and add the Discord and QQ contacts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/lshw54/maplelink/releases"><img src="https://img.shields.io/github/downloads/lshw54/maplelink/total" alt="Downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License" /></a>
   <a href="https://lshw54.github.io/maplelink/"><img src="https://img.shields.io/badge/website-maplelink-e11d48" alt="Website" /></a>
+  <a href="https://discord.gg/uUn9aAm9ww"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
 <p align="center">
@@ -233,6 +234,7 @@ npm run format                                     # Prettier format
 ## Contact
 
 - Bug reports and feature requests: [GitHub Issues](../../issues)
+- Discord: [https://discord.gg/uUn9aAm9ww](https://discord.gg/uUn9aAm9ww)
 - QQ: `2157875454`
 
 ## Contributing

--- a/README.en.md
+++ b/README.en.md
@@ -12,15 +12,18 @@
   <a href="https://github.com/lshw54/maplelink/releases/latest"><img src="https://img.shields.io/github/v/release/lshw54/maplelink?include_prereleases&label=version" alt="Version" /></a>
   <a href="https://github.com/lshw54/maplelink/releases"><img src="https://img.shields.io/github/downloads/lshw54/maplelink/total" alt="Downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License" /></a>
+  <a href="https://lshw54.github.io/maplelink/"><img src="https://img.shields.io/badge/website-maplelink-e11d48" alt="Website" /></a>
 </p>
 
 <p align="center">
-  <a href="../../releases/latest">Download</a> · <a href="#features">Features</a> · <a href="#development">Dev Guide</a> · <a href="README.md">繁體中文</a>
+  <a href="https://lshw54.github.io/maplelink/">Website</a> · <a href="https://lshw54.github.io/maplelink/download">Download</a> · <a href="https://lshw54.github.io/maplelink/guide">Getting Started</a> · <a href="https://lshw54.github.io/maplelink/faq">FAQ</a> · <a href="#features">Features</a> · <a href="#development">Dev Guide</a> · <a href="README.md">繁體中文</a>
 </p>
 
 ---
 
 ⚠️ **This is NOT an official Gamania product.** Use at your own risk. Make sure you trust where you got this from.
+
+📖 Downloads, the getting-started guide and the FAQ all live on the **[official website](https://lshw54.github.io/maplelink/)**.
 
 > **📢 Parallel Development Notice (Project Status)**
 >
@@ -72,8 +75,10 @@ The original [Beanfun launcher](https://github.com/pungin/Beanfun) served well b
 
 **Requirements:** Windows 10+, [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/) (built into Win11)
 
-1. Grab the latest build from [Releases](../../releases/latest)
+1. Grab the latest build from the [download page](https://lshw54.github.io/maplelink/download), or straight from [GitHub Releases](../../releases/latest)
 2. Unzip and run — nothing to install
+
+First time here? Walk through the [getting-started guide](https://lshw54.github.io/maplelink/guide); if something goes wrong, check the [FAQ](https://lshw54.github.io/maplelink/faq) first.
 
 > The `EBWebView` folder in `%APPDATA%` is WebView2's cache — this is normal. Enable "GamaPass Incognito Mode" in settings if you don't want it saving login sessions.
 

--- a/README.en.md
+++ b/README.en.md
@@ -230,6 +230,11 @@ npm run format                                     # Prettier format
 # feat: / fix: / refactor: / chore: ...
 ```
 
+## Contact
+
+- Bug reports and feature requests: [GitHub Issues](../../issues)
+- QQ: `2157875454`
+
 ## Contributing
 
 Fork → branch → test → PR.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ npm run format                                     # Prettier 格式化
 # feat: / fix: / refactor: / chore: ...
 ```
 
+## 交流與回報
+
+- 問題回報、功能建議：[GitHub Issues](../../issues)
+- QQ：`2157875454`
+
 ## 貢獻方式
 
 Fork → 建立分支 → 測試 → 發送 PR。

--- a/README.md
+++ b/README.md
@@ -12,15 +12,18 @@
   <a href="https://github.com/lshw54/maplelink/releases/latest"><img src="https://img.shields.io/github/v/release/lshw54/maplelink?include_prereleases&label=version" alt="Version" /></a>
   <a href="https://github.com/lshw54/maplelink/releases"><img src="https://img.shields.io/github/downloads/lshw54/maplelink/total" alt="Downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License" /></a>
+  <a href="https://lshw54.github.io/maplelink/"><img src="https://img.shields.io/badge/website-maplelink-e11d48" alt="Website" /></a>
 </p>
 
 <p align="center">
-  <a href="../../releases/latest">下載</a> · <a href="#功能特色">功能</a> · <a href="#開發指南">開發</a> · <a href="README.en.md">English</a>
+  <a href="https://lshw54.github.io/maplelink/">官方網站</a> · <a href="https://lshw54.github.io/maplelink/download">下載</a> · <a href="https://lshw54.github.io/maplelink/guide">新手教學</a> · <a href="https://lshw54.github.io/maplelink/faq">常見問題</a> · <a href="#功能特色">功能</a> · <a href="#開發指南">開發</a> · <a href="README.en.md">English</a>
 </p>
 
 ---
 
 ⚠️ **本程式並非遊戲橘子官方產品。** 使用前請自行評估風險，並確認下載來源是否安全。
+
+📖 下載、新手教學與常見問題都在 **[官方網站](https://lshw54.github.io/maplelink/)**。
 
 > **📢 雙線並行開發公告 (Project Status)**
 >
@@ -72,8 +75,10 @@
 
 **系統需求：** Windows 10 以上、[WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)（Win11 已內建）
 
-1. 前往 [Releases](../../releases/latest) 下載最新版本
+1. 前往[下載頁](https://lshw54.github.io/maplelink/download)取得最新版本，或直接到 [GitHub Releases](../../releases/latest)
 2. 解壓後直接執行，無需安裝
+
+第一次使用建議跟著[新手教學](https://lshw54.github.io/maplelink/guide)走一遍，遇到問題先看[常見問題](https://lshw54.github.io/maplelink/faq)。
 
 > `%APPDATA%` 中的 `EBWebView` 資料夾是 WebView2 的快取，屬於正常現象。若不想保留 GamaPass 的登入狀態，可在設定中開啟「GamaPass 無痕模式」。
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/lshw54/maplelink/releases"><img src="https://img.shields.io/github/downloads/lshw54/maplelink/total" alt="Downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License" /></a>
   <a href="https://lshw54.github.io/maplelink/"><img src="https://img.shields.io/badge/website-maplelink-e11d48" alt="Website" /></a>
+  <a href="https://discord.gg/uUn9aAm9ww"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
 <p align="center">
@@ -233,6 +234,7 @@ npm run format                                     # Prettier 格式化
 ## 交流與回報
 
 - 問題回報、功能建議：[GitHub Issues](../../issues)
+- Discord：[https://discord.gg/uUn9aAm9ww](https://discord.gg/uUn9aAm9ww)
 - QQ：`2157875454`
 
 ## 貢獻方式

--- a/site/docs/faq.mdx
+++ b/site/docs/faq.mdx
@@ -161,6 +161,6 @@ TW 一般帳密登入需要通過 reCAPTCHA。
 
 ### 如何回報問題
 
-到 [GitHub Issues](https://github.com/lshw54/maplelink/issues) 開一則 issue，附上程式版本、地區與重現步驟。
+附上程式版本、地區與重現步驟：
 
-不方便用 GitHub 的話，可以來 [Discord](https://discord.gg/uUn9aAm9ww)，或者用 QQ 聯絡：`2157875454`。
+[GitHub Issues](https://github.com/lshw54/maplelink/issues) · [Discord](https://discord.gg/uUn9aAm9ww) · QQ `2157875454`

--- a/site/docs/faq.mdx
+++ b/site/docs/faq.mdx
@@ -163,4 +163,4 @@ TW 一般帳密登入需要通過 reCAPTCHA。
 
 到 [GitHub Issues](https://github.com/lshw54/maplelink/issues) 開一則 issue，附上程式版本、地區與重現步驟。
 
-不方便用 GitHub 的話，也可以用 QQ 聯絡：`2157875454`。
+不方便用 GitHub 的話，可以來 [Discord](https://discord.gg/uUn9aAm9ww)，或者用 QQ 聯絡：`2157875454`。

--- a/site/docs/faq.mdx
+++ b/site/docs/faq.mdx
@@ -162,3 +162,5 @@ TW 一般帳密登入需要通過 reCAPTCHA。
 ### 如何回報問題
 
 到 [GitHub Issues](https://github.com/lshw54/maplelink/issues) 開一則 issue，附上程式版本、地區與重現步驟。
+
+不方便用 GitHub 的話，也可以用 QQ 聯絡：`2157875454`。

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -53,10 +53,12 @@ const config: Config = {
   i18n: {
     defaultLocale: "zh-TW",
     locales: ["zh-TW", "zh-CN", "en"],
+    // Short labels: the locale dropdown prints the current locale's label in
+    // the navbar, and "繁體中文" next to the search box left no room to breathe.
     localeConfigs: {
-      "zh-TW": { label: "繁體中文", htmlLang: "zh-TW" },
-      "zh-CN": { label: "简体中文", htmlLang: "zh-CN" },
-      en: { label: "English", htmlLang: "en-US" },
+      "zh-TW": { label: "繁中", htmlLang: "zh-TW" },
+      "zh-CN": { label: "简中", htmlLang: "zh-CN" },
+      en: { label: "EN", htmlLang: "en-US" },
     },
   },
 

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
@@ -160,3 +160,5 @@ Both are maintained side by side by the same people. MapleLink is built for Mapl
 ### How do I report a problem
 
 Open an issue on [GitHub](https://github.com/lshw54/maplelink/issues) with the app version, region and steps to reproduce.
+
+If GitHub is awkward for you, reach us on QQ instead: `2157875454`.

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
@@ -161,4 +161,4 @@ Both are maintained side by side by the same people. MapleLink is built for Mapl
 
 Open an issue on [GitHub](https://github.com/lshw54/maplelink/issues) with the app version, region and steps to reproduce.
 
-If GitHub is awkward for you, reach us on QQ instead: `2157875454`.
+If GitHub is awkward for you, join our [Discord](https://discord.gg/uUn9aAm9ww) or reach us on QQ: `2157875454`.

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
@@ -159,6 +159,6 @@ Both are maintained side by side by the same people. MapleLink is built for Mapl
 
 ### How do I report a problem
 
-Open an issue on [GitHub](https://github.com/lshw54/maplelink/issues) with the app version, region and steps to reproduce.
+Include the app version, region and steps to reproduce:
 
-If GitHub is awkward for you, join our [Discord](https://discord.gg/uUn9aAm9ww) or reach us on QQ: `2157875454`.
+[GitHub Issues](https://github.com/lshw54/maplelink/issues) · [Discord](https://discord.gg/uUn9aAm9ww) · QQ `2157875454`

--- a/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq.mdx
@@ -161,6 +161,6 @@ TW 一般账密登录需要通过 reCAPTCHA。
 
 ### 如何反馈问题
 
-到 [GitHub Issues](https://github.com/lshw54/maplelink/issues) 开一则 issue，附上程序版本、地区与复现步骤。
+附上程序版本、地区与复现步骤：
 
-不方便用 GitHub 的话，可以来 [Discord](https://discord.gg/uUn9aAm9ww)，或者用 QQ 联系：`2157875454`。
+[GitHub Issues](https://github.com/lshw54/maplelink/issues) · [Discord](https://discord.gg/uUn9aAm9ww) · QQ `2157875454`

--- a/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq.mdx
@@ -162,3 +162,5 @@ TW 一般账密登录需要通过 reCAPTCHA。
 ### 如何反馈问题
 
 到 [GitHub Issues](https://github.com/lshw54/maplelink/issues) 开一则 issue，附上程序版本、地区与复现步骤。
+
+不方便用 GitHub 的话，也可以用 QQ 联系：`2157875454`。

--- a/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq.mdx
@@ -163,4 +163,4 @@ TW 一般账密登录需要通过 reCAPTCHA。
 
 到 [GitHub Issues](https://github.com/lshw54/maplelink/issues) 开一则 issue，附上程序版本、地区与复现步骤。
 
-不方便用 GitHub 的话，也可以用 QQ 联系：`2157875454`。
+不方便用 GitHub 的话，可以来 [Discord](https://discord.gg/uUn9aAm9ww)，或者用 QQ 联系：`2157875454`。

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -22,7 +22,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["也玩其他橘子遊戲？我們同時維護原版 ", "Beanfun", " 啟動器。"],
     help: [
       { h: "開始使用", items: [[["/guide", "新手教學"], "：下載、解壓、登入、取 OTP，約五分鐘"], ["需要 Windows 10 / 11（64 位元）及 WebView2"], ["不需要安裝，整個資料夾放哪裏都可以"]] },
-      { h: "遇到問題", items: [[["/faq#webview2", "打不開、白屏、閃退"], "：安裝 WebView2"], [["/faq", "SmartScreen 警告、防毒誤判、加速器認不到"]], ["其他問題到 ", [`${REPO}/issues`, "GitHub Issues"], " 回報，或者來 ", [DISCORD, "Discord"], "，QQ：" + QQ]] },
+      { h: "遇到問題", items: [[["/faq#webview2", "打不開、白屏、閃退"], "：安裝 WebView2"], [["/faq", "SmartScreen 警告、防毒誤判、加速器認不到"]], [[DISCORD, "Discord"], " · ", [`${REPO}/issues`, "GitHub Issues"], " · QQ " + QQ]] },
       { h: "下載與更新", items: [["只從本站或 ", [`${REPO}/releases`, "GitHub Releases"], " 下載"], ["執行前", ["/download#verify", "核對 SHA256"], "，不一致就刪除"], ["已在使用的話，程式會自動更新"]] },
     ],
     legal1: ["MapleLink 與 ", "Beanfun", " 均為第三方開放原始碼軟體，由同一批人並行維護，與遊戲橘子（Gamania）、beanfun! 及 Nexon 沒有任何關聯，也不是它們的官方產品。使用第三方啟動器可能違反遊戲服務條款，請自行評估風險；因使用本軟體造成的任何帳號或財物損失，開發團隊不承擔責任。"],
@@ -37,7 +37,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["也玩其他橘子游戏？我们同时维护原版 ", "Beanfun", " 启动器。"],
     help: [
       { h: "开始使用", items: [[["/guide", "新手教学"], "：下载、解压、登录、取 OTP，约五分钟"], ["需要 Windows 10 / 11（64 位）及 WebView2"], ["不需要安装，整个文件夹放哪里都可以"]] },
-      { h: "遇到问题", items: [[["/faq#webview2", "打不开、白屏、闪退"], "：安装 WebView2"], [["/faq", "SmartScreen 警告、杀毒误判、加速器认不到"]], ["其他问题到 ", [`${REPO}/issues`, "GitHub Issues"], " 反馈，或者来 ", [DISCORD, "Discord"], "，QQ：" + QQ]] },
+      { h: "遇到问题", items: [[["/faq#webview2", "打不开、白屏、闪退"], "：安装 WebView2"], [["/faq", "SmartScreen 警告、杀毒误判、加速器认不到"]], [[DISCORD, "Discord"], " · ", [`${REPO}/issues`, "GitHub Issues"], " · QQ " + QQ]] },
       { h: "下载与更新", items: [["只从本站或 ", [`${REPO}/releases`, "GitHub Releases"], " 下载"], ["运行前", ["/download#verify", "核对 SHA256"], "，不一致就删除"], ["已在使用的话，程序会自动更新"]] },
     ],
     legal1: ["MapleLink 与 ", "Beanfun", " 均为第三方开放源代码软件，由同一批人并行维护，与游戏橘子（Gamania）、beanfun! 及 Nexon 没有任何关联，也不是它们的官方产品。使用第三方启动器可能违反游戏服务条款，请自行评估风险；因使用本软件造成的任何账号或财物损失，开发团队不承担责任。"],
@@ -52,7 +52,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["Play other Gamania games too? We also maintain the original ", "Beanfun", " launcher."],
     help: [
       { h: "Getting started", items: [[["/guide", "Beginner guide"], ": download, unpack, sign in, get an OTP. About five minutes"], ["Needs Windows 10 / 11 (64-bit) and WebView2"], ["Nothing to install. Keep the folder anywhere"]] },
-      { h: "Something wrong?", items: [[["/faq#webview2", "Won't open, blank window, closes at once"], ": install WebView2"], [["/faq", "SmartScreen warning, antivirus flag, accelerator can't see it"]], ["Anything else: open an issue on ", [`${REPO}/issues`, "GitHub"], ", join our ", [DISCORD, "Discord"], ", or reach us on QQ: " + QQ]] },
+      { h: "Something wrong?", items: [[["/faq#webview2", "Won't open, blank window, closes at once"], ": install WebView2"], [["/faq", "SmartScreen warning, antivirus flag, accelerator can't see it"]], [[DISCORD, "Discord"], " · ", [`${REPO}/issues`, "GitHub Issues"], " · QQ " + QQ]] },
       { h: "Downloads and updates", items: [["Download only from this site or ", [`${REPO}/releases`, "GitHub Releases"]], [["/download#verify", "Check the SHA256"], " before running; delete it if it differs"], ["Once installed, the app updates itself"]] },
     ],
     legal1: ["MapleLink and ", "Beanfun", " are third-party open-source software maintained side by side by the same people. They are not affiliated with Gamania, beanfun! or Nexon and are not their official products. Using a third-party launcher may breach a game's terms of service; assess the risk yourself. The developers accept no liability for any account or financial loss arising from use of this software."],

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -9,6 +9,7 @@ const BEANFUN = "https://github.com/pungin/Beanfun";
 const REPO = "https://github.com/lshw54/maplelink";
 const LICENSE = `${REPO}/blob/main/LICENSE`;
 const QQ = "2157875454";
+const DISCORD = "https://discord.gg/uUn9aAm9ww";
 
 /** Per-locale copy. Paths are locale-relative; Link adds the base, Docusaurus adds the locale. */
 const COPY: Record<Locale, Copy> = {
@@ -21,7 +22,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["也玩其他橘子遊戲？我們同時維護原版 ", "Beanfun", " 啟動器。"],
     help: [
       { h: "開始使用", items: [[["/guide", "新手教學"], "：下載、解壓、登入、取 OTP，約五分鐘"], ["需要 Windows 10 / 11（64 位元）及 WebView2"], ["不需要安裝，整個資料夾放哪裏都可以"]] },
-      { h: "遇到問題", items: [[["/faq#webview2", "打不開、白屏、閃退"], "：安裝 WebView2"], [["/faq", "SmartScreen 警告、防毒誤判、加速器認不到"]], ["其他問題到 ", [`${REPO}/issues`, "GitHub Issues"], " 回報，或用 QQ 聯絡我們：" + QQ]] },
+      { h: "遇到問題", items: [[["/faq#webview2", "打不開、白屏、閃退"], "：安裝 WebView2"], [["/faq", "SmartScreen 警告、防毒誤判、加速器認不到"]], ["其他問題到 ", [`${REPO}/issues`, "GitHub Issues"], " 回報，或者來 ", [DISCORD, "Discord"], "，QQ：" + QQ]] },
       { h: "下載與更新", items: [["只從本站或 ", [`${REPO}/releases`, "GitHub Releases"], " 下載"], ["執行前", ["/download#verify", "核對 SHA256"], "，不一致就刪除"], ["已在使用的話，程式會自動更新"]] },
     ],
     legal1: ["MapleLink 與 ", "Beanfun", " 均為第三方開放原始碼軟體，由同一批人並行維護，與遊戲橘子（Gamania）、beanfun! 及 Nexon 沒有任何關聯，也不是它們的官方產品。使用第三方啟動器可能違反遊戲服務條款，請自行評估風險；因使用本軟體造成的任何帳號或財物損失，開發團隊不承擔責任。"],
@@ -36,7 +37,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["也玩其他橘子游戏？我们同时维护原版 ", "Beanfun", " 启动器。"],
     help: [
       { h: "开始使用", items: [[["/guide", "新手教学"], "：下载、解压、登录、取 OTP，约五分钟"], ["需要 Windows 10 / 11（64 位）及 WebView2"], ["不需要安装，整个文件夹放哪里都可以"]] },
-      { h: "遇到问题", items: [[["/faq#webview2", "打不开、白屏、闪退"], "：安装 WebView2"], [["/faq", "SmartScreen 警告、杀毒误判、加速器认不到"]], ["其他问题到 ", [`${REPO}/issues`, "GitHub Issues"], " 反馈，或用 QQ 联系我们：" + QQ]] },
+      { h: "遇到问题", items: [[["/faq#webview2", "打不开、白屏、闪退"], "：安装 WebView2"], [["/faq", "SmartScreen 警告、杀毒误判、加速器认不到"]], ["其他问题到 ", [`${REPO}/issues`, "GitHub Issues"], " 反馈，或者来 ", [DISCORD, "Discord"], "，QQ：" + QQ]] },
       { h: "下载与更新", items: [["只从本站或 ", [`${REPO}/releases`, "GitHub Releases"], " 下载"], ["运行前", ["/download#verify", "核对 SHA256"], "，不一致就删除"], ["已在使用的话，程序会自动更新"]] },
     ],
     legal1: ["MapleLink 与 ", "Beanfun", " 均为第三方开放源代码软件，由同一批人并行维护，与游戏橘子（Gamania）、beanfun! 及 Nexon 没有任何关联，也不是它们的官方产品。使用第三方启动器可能违反游戏服务条款，请自行评估风险；因使用本软件造成的任何账号或财物损失，开发团队不承担责任。"],
@@ -51,7 +52,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["Play other Gamania games too? We also maintain the original ", "Beanfun", " launcher."],
     help: [
       { h: "Getting started", items: [[["/guide", "Beginner guide"], ": download, unpack, sign in, get an OTP. About five minutes"], ["Needs Windows 10 / 11 (64-bit) and WebView2"], ["Nothing to install. Keep the folder anywhere"]] },
-      { h: "Something wrong?", items: [[["/faq#webview2", "Won't open, blank window, closes at once"], ": install WebView2"], [["/faq", "SmartScreen warning, antivirus flag, accelerator can't see it"]], ["Anything else: open an issue on ", [`${REPO}/issues`, "GitHub"], ", or reach us on QQ: " + QQ]] },
+      { h: "Something wrong?", items: [[["/faq#webview2", "Won't open, blank window, closes at once"], ": install WebView2"], [["/faq", "SmartScreen warning, antivirus flag, accelerator can't see it"]], ["Anything else: open an issue on ", [`${REPO}/issues`, "GitHub"], ", join our ", [DISCORD, "Discord"], ", or reach us on QQ: " + QQ]] },
       { h: "Downloads and updates", items: [["Download only from this site or ", [`${REPO}/releases`, "GitHub Releases"]], [["/download#verify", "Check the SHA256"], " before running; delete it if it differs"], ["Once installed, the app updates itself"]] },
     ],
     legal1: ["MapleLink and ", "Beanfun", " are third-party open-source software maintained side by side by the same people. They are not affiliated with Gamania, beanfun! or Nexon and are not their official products. Using a third-party launcher may breach a game's terms of service; assess the risk yourself. The developers accept no liability for any account or financial loss arising from use of this software."],

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -8,6 +8,7 @@ import AppWindow from "../demo/AppWindow";
 const BEANFUN = "https://github.com/pungin/Beanfun";
 const REPO = "https://github.com/lshw54/maplelink";
 const LICENSE = `${REPO}/blob/main/LICENSE`;
+const QQ = "2157875454";
 
 /** Per-locale copy. Paths are locale-relative; Link adds the base, Docusaurus adds the locale. */
 const COPY: Record<Locale, Copy> = {
@@ -20,7 +21,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["也玩其他橘子遊戲？我們同時維護原版 ", "Beanfun", " 啟動器。"],
     help: [
       { h: "開始使用", items: [[["/guide", "新手教學"], "：下載、解壓、登入、取 OTP，約五分鐘"], ["需要 Windows 10 / 11（64 位元）及 WebView2"], ["不需要安裝，整個資料夾放哪裏都可以"]] },
-      { h: "遇到問題", items: [[["/faq#webview2", "打不開、白屏、閃退"], "：安裝 WebView2"], [["/faq", "SmartScreen 警告、防毒誤判、加速器認不到"]], ["其他問題到 ", [`${REPO}/issues`, "GitHub Issues"], " 回報"]] },
+      { h: "遇到問題", items: [[["/faq#webview2", "打不開、白屏、閃退"], "：安裝 WebView2"], [["/faq", "SmartScreen 警告、防毒誤判、加速器認不到"]], ["其他問題到 ", [`${REPO}/issues`, "GitHub Issues"], " 回報，或用 QQ 聯絡我們：" + QQ]] },
       { h: "下載與更新", items: [["只從本站或 ", [`${REPO}/releases`, "GitHub Releases"], " 下載"], ["執行前", ["/download#verify", "核對 SHA256"], "，不一致就刪除"], ["已在使用的話，程式會自動更新"]] },
     ],
     legal1: ["MapleLink 與 ", "Beanfun", " 均為第三方開放原始碼軟體，由同一批人並行維護，與遊戲橘子（Gamania）、beanfun! 及 Nexon 沒有任何關聯，也不是它們的官方產品。使用第三方啟動器可能違反遊戲服務條款，請自行評估風險；因使用本軟體造成的任何帳號或財物損失，開發團隊不承擔責任。"],
@@ -35,7 +36,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["也玩其他橘子游戏？我们同时维护原版 ", "Beanfun", " 启动器。"],
     help: [
       { h: "开始使用", items: [[["/guide", "新手教学"], "：下载、解压、登录、取 OTP，约五分钟"], ["需要 Windows 10 / 11（64 位）及 WebView2"], ["不需要安装，整个文件夹放哪里都可以"]] },
-      { h: "遇到问题", items: [[["/faq#webview2", "打不开、白屏、闪退"], "：安装 WebView2"], [["/faq", "SmartScreen 警告、杀毒误判、加速器认不到"]], ["其他问题到 ", [`${REPO}/issues`, "GitHub Issues"], " 反馈"]] },
+      { h: "遇到问题", items: [[["/faq#webview2", "打不开、白屏、闪退"], "：安装 WebView2"], [["/faq", "SmartScreen 警告、杀毒误判、加速器认不到"]], ["其他问题到 ", [`${REPO}/issues`, "GitHub Issues"], " 反馈，或用 QQ 联系我们：" + QQ]] },
       { h: "下载与更新", items: [["只从本站或 ", [`${REPO}/releases`, "GitHub Releases"], " 下载"], ["运行前", ["/download#verify", "核对 SHA256"], "，不一致就删除"], ["已在使用的话，程序会自动更新"]] },
     ],
     legal1: ["MapleLink 与 ", "Beanfun", " 均为第三方开放源代码软件，由同一批人并行维护，与游戏橘子（Gamania）、beanfun! 及 Nexon 没有任何关联，也不是它们的官方产品。使用第三方启动器可能违反游戏服务条款，请自行评估风险；因使用本软件造成的任何账号或财物损失，开发团队不承担责任。"],
@@ -50,7 +51,7 @@ const COPY: Record<Locale, Copy> = {
     fine2: ["Play other Gamania games too? We also maintain the original ", "Beanfun", " launcher."],
     help: [
       { h: "Getting started", items: [[["/guide", "Beginner guide"], ": download, unpack, sign in, get an OTP. About five minutes"], ["Needs Windows 10 / 11 (64-bit) and WebView2"], ["Nothing to install. Keep the folder anywhere"]] },
-      { h: "Something wrong?", items: [[["/faq#webview2", "Won't open, blank window, closes at once"], ": install WebView2"], [["/faq", "SmartScreen warning, antivirus flag, accelerator can't see it"]], ["Anything else: open an issue on ", [`${REPO}/issues`, "GitHub"]]] },
+      { h: "Something wrong?", items: [[["/faq#webview2", "Won't open, blank window, closes at once"], ": install WebView2"], [["/faq", "SmartScreen warning, antivirus flag, accelerator can't see it"]], ["Anything else: open an issue on ", [`${REPO}/issues`, "GitHub"], ", or reach us on QQ: " + QQ]] },
       { h: "Downloads and updates", items: [["Download only from this site or ", [`${REPO}/releases`, "GitHub Releases"]], [["/download#verify", "Check the SHA256"], " before running; delete it if it differs"], ["Once installed, the app updates itself"]] },
     ],
     legal1: ["MapleLink and ", "Beanfun", " are third-party open-source software maintained side by side by the same people. They are not affiliated with Gamania, beanfun! or Nexon and are not their official products. Using a third-party launcher may breach a game's terms of service; assess the risk yourself. The developers accept no liability for any account or financial loss arising from use of this software."],

--- a/src/components/icons/AboutIcons.tsx
+++ b/src/components/icons/AboutIcons.tsx
@@ -1,0 +1,72 @@
+/**
+ * Marks for the About tab's link tiles.
+ *
+ * Drawn rather than set as emoji: the emoji versions render at different
+ * weights and colours depending on the fonts a player has, which made the
+ * tiles look like a jumble. Stroke glyphs inherit `currentColor`; the two
+ * brand marks are solid, the way those logos are meant to be drawn.
+ */
+
+const stroke = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.8,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+  "aria-hidden": true,
+} as const;
+
+export function GlobeIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...stroke} className={className}>
+      <circle cx="12" cy="12" r="9.5" />
+      <path d="M2.5 12h19" />
+      <path d="M12 2.5a14 14 0 0 1 0 19a14 14 0 0 1 0-19Z" />
+    </svg>
+  );
+}
+
+export function BookIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...stroke} className={className}>
+      <path d="M12 6.5C10.5 5 8.5 4.5 4 4.5v13c4.5 0 6.5.5 8 2 1.5-1.5 3.5-2 8-2v-13c-4.5 0-6.5.5-8 2Z" />
+      <path d="M12 6.5v13" />
+    </svg>
+  );
+}
+
+export function BugIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...stroke} className={className}>
+      <rect x="8" y="7" width="8" height="13" rx="4" />
+      <path d="M9.5 7a2.5 2.5 0 0 1 5 0" />
+      <path d="M8 11H4.5M16 11h3.5M8 15.5H4.5M16 15.5h3.5M9 19l-2 2.5M15 19l2 2.5M9 7.5 7.5 5M15 7.5 16.5 5" />
+    </svg>
+  );
+}
+
+export function ChatIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...stroke} className={className}>
+      <path d="M20.5 12.5c0 4-3.8 7-8.5 7a10 10 0 0 1-2.6-.34l-4.9 1.6 1.6-3.7A6.6 6.6 0 0 1 3.5 12.5c0-3.9 3.8-7 8.5-7s8.5 3.1 8.5 7Z" />
+      <path d="M9 12h.01M12 12h.01M15 12h.01" />
+    </svg>
+  );
+}
+
+export function GitHubIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className={className}>
+      <path d="M12 .5C5.73.5.75 5.48.75 11.75c0 4.96 3.22 9.16 7.69 10.65.56.1.77-.24.77-.54v-2.1c-3.13.68-3.79-1.32-3.79-1.32-.51-1.3-1.25-1.65-1.25-1.65-1.02-.7.08-.68.08-.68 1.13.08 1.73 1.16 1.73 1.16 1 1.72 2.64 1.22 3.28.94.1-.73.39-1.23.71-1.51-2.5-.29-5.13-1.25-5.13-5.57 0-1.23.44-2.24 1.16-3.03-.12-.29-.5-1.43.11-2.99 0 0 .95-.3 3.1 1.16a10.7 10.7 0 0 1 5.64 0c2.15-1.46 3.09-1.16 3.09-1.16.62 1.56.23 2.7.12 2.99.72.79 1.16 1.8 1.16 3.03 0 4.33-2.64 5.28-5.15 5.56.4.35.77 1.04.77 2.1v3.11c0 .3.2.65.78.54a11.26 11.26 0 0 0 7.68-10.65C23.25 5.48 18.27.5 12 .5Z" />
+    </svg>
+  );
+}
+
+export function DiscordIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className={className}>
+      <path d="M19.54 5.34A16.4 16.4 0 0 0 15.5 4.1l-.2.38c-.25.45-.53 1.04-.72 1.5a15.3 15.3 0 0 0-5.16 0c-.2-.46-.48-1.05-.73-1.5l-.2-.38a16.4 16.4 0 0 0-4.03 1.24C1.9 9.13 1.2 12.8 1.55 16.42a16.6 16.6 0 0 0 5.02 2.54c.4-.55.77-1.14 1.08-1.76a10.8 10.8 0 0 1-1.7-.82l.42-.33a11.6 11.6 0 0 0 9.94 0l.42.33c-.54.32-1.11.6-1.71.82.31.62.67 1.2 1.08 1.76a16.6 16.6 0 0 0 5.03-2.54c.42-4.2-.7-7.83-2.59-11.08ZM8.52 14.23c-.98 0-1.79-.9-1.79-2.01 0-1.11.79-2.02 1.79-2.02s1.81.91 1.79 2.02c0 1.1-.79 2.01-1.79 2.01Zm6.6 0c-.98 0-1.79-.9-1.79-2.01 0-1.11.79-2.02 1.79-2.02s1.8.91 1.79 2.02c0 1.1-.79 2.01-1.79 2.01Z" />
+    </svg>
+  );
+}

--- a/src/features/toolbox/AboutTab.tsx
+++ b/src/features/toolbox/AboutTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import { useTranslation } from "../../lib/i18n";
 import { useUiStore } from "../../lib/stores/ui-store";
 import { useConfigStore } from "../../lib/stores/config-store";
@@ -6,6 +6,14 @@ import { commands } from "../../lib/tauri";
 import { useUpdateStore } from "../../lib/stores/update-store";
 import { UpdateDialog } from "../shared/UpdateDialog";
 import type { UpdateInfoDto } from "../../lib/types";
+import {
+  GlobeIcon,
+  BookIcon,
+  BugIcon,
+  ChatIcon,
+  GitHubIcon,
+  DiscordIcon,
+} from "../../components/icons/AboutIcons";
 
 /** Community contacts for players who cannot or will not use GitHub. Also on the site. */
 const QQ_CONTACT = "2157875454";
@@ -126,34 +134,38 @@ export function AboutTab() {
         <InfoRow label={t("toolbox.about.license_label")} value="MIT License" last />
       </div>
 
-      {/* Links */}
-      <div className="overflow-hidden rounded-[10px] border border-[var(--tb-border)]">
-        <LinkRow
-          icon="🌐"
+      {/* Links, two per line — six stacked rows read as one long wall. */}
+      <div className="grid grid-cols-2 gap-1.5">
+        <Tile
+          icon={<GlobeIcon className="h-3.5 w-3.5" />}
           label={t("toolbox.about.website")}
           onClick={() => openExternal("https://lshw54.github.io/maplelink/")}
         />
-        <LinkRow
-          icon="📖"
+        <Tile
+          icon={<BookIcon className="h-3.5 w-3.5" />}
           label={t("toolbox.about.guide")}
           onClick={() => openExternal("https://lshw54.github.io/maplelink/guide")}
         />
-        <LinkRow
-          icon="🔗"
+        <Tile
+          icon={<GitHubIcon className="h-3.5 w-3.5" />}
           label={t("toolbox.about.github_project")}
           onClick={() => openExternal("https://github.com/lshw54/maplelink")}
         />
-        <LinkRow
-          icon="🐛"
+        <Tile
+          icon={<BugIcon className="h-3.5 w-3.5" />}
           label={t("toolbox.about.issues")}
           onClick={() => openExternal("https://github.com/lshw54/maplelink/issues")}
         />
-        <LinkRow
-          icon="💬"
+        <Tile
+          icon={<DiscordIcon className="h-3.5 w-3.5" />}
           label={t("toolbox.about.discord")}
           onClick={() => openExternal(DISCORD_INVITE)}
         />
-        <CopyRow icon="🐧" label={t("toolbox.about.qq")} value={QQ_CONTACT} last />
+        <CopyTile
+          icon={<ChatIcon className="h-3.5 w-3.5" />}
+          label={t("toolbox.about.qq")}
+          value={QQ_CONTACT}
+        />
       </div>
 
       {/* Copyright */}
@@ -181,18 +193,22 @@ function InfoRow({ label, value, last }: { label: string; value: string; last?: 
   );
 }
 
-/** A row whose value is copied to the clipboard instead of opened. */
-function CopyRow({
-  icon,
-  label,
-  value,
-  last,
-}: {
-  icon: string;
-  label: string;
-  value: string;
-  last?: boolean;
-}) {
+const TILE =
+  "flex items-center gap-2 rounded-[10px] border border-[var(--tb-border)] bg-[var(--tb-card)] px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] hover:text-accent";
+
+/** One link tile: mark, label, and the outbound arrow. */
+function Tile({ icon, label, onClick }: { icon: ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button onClick={onClick} className={TILE}>
+      <span className="shrink-0 text-text-dim">{icon}</span>
+      <span className="flex-1 truncate text-[11px] font-medium text-[var(--text)]">{label}</span>
+      <span className="shrink-0 text-[10px] text-text-faint">↗</span>
+    </button>
+  );
+}
+
+/** Same tile, but the value is copied to the clipboard instead of opened. */
+function CopyTile({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
 
@@ -210,41 +226,14 @@ function CopyRow({
           .then(() => setCopied(true))
           .catch(() => {});
       }}
-      className={`flex w-full items-center gap-2.5 bg-[var(--tb-card)] px-4 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] ${
-        last ? "" : "border-b border-[var(--tb-border)]"
-      }`}
+      className={TILE}
+      title={value}
     >
-      <span className="w-4 text-center text-xs">{icon}</span>
-      <span className="flex-1 text-[11px] font-medium text-[var(--text)]">{label}</span>
-      <span className="font-mono text-[11px] text-text-dim">{value}</span>
-      <span className="w-12 text-right text-[10px] text-text-faint">
-        {copied ? t("common.copied") : t("common.copy")}
+      <span className="shrink-0 text-text-dim">{icon}</span>
+      <span className="flex-1 truncate text-[11px] font-medium text-[var(--text)]">{label}</span>
+      <span className={`shrink-0 text-[10px] ${copied ? "text-accent" : "text-text-faint"}`}>
+        {copied ? t("common.copied") : value}
       </span>
-    </button>
-  );
-}
-
-function LinkRow({
-  icon,
-  label,
-  onClick,
-  last,
-}: {
-  icon: string;
-  label: string;
-  onClick: () => void;
-  last?: boolean;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`flex w-full items-center gap-2.5 bg-[var(--tb-card)] px-4 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] ${
-        last ? "" : "border-b border-[var(--tb-border)]"
-      }`}
-    >
-      <span className="w-4 text-center text-xs">{icon}</span>
-      <span className="flex-1 text-[11px] font-medium text-[var(--text)]">{label}</span>
-      <span className="text-[10px] text-text-faint">↗</span>
     </button>
   );
 }

--- a/src/features/toolbox/AboutTab.tsx
+++ b/src/features/toolbox/AboutTab.tsx
@@ -7,6 +7,9 @@ import { useUpdateStore } from "../../lib/stores/update-store";
 import { UpdateDialog } from "../shared/UpdateDialog";
 import type { UpdateInfoDto } from "../../lib/types";
 
+/** Contact for players who cannot or will not use GitHub. Also listed on the site. */
+const QQ_CONTACT = "2157875454";
+
 export function AboutTab() {
   const { t } = useTranslation();
   const [appVersion, setAppVersion] = useState("...");
@@ -143,8 +146,8 @@ export function AboutTab() {
           icon="🐛"
           label={t("toolbox.about.issues")}
           onClick={() => openExternal("https://github.com/lshw54/maplelink/issues")}
-          last
         />
+        <CopyRow icon="💬" label={t("toolbox.about.qq")} value={QQ_CONTACT} last />
       </div>
 
       {/* Copyright */}
@@ -169,6 +172,49 @@ function InfoRow({ label, value, last }: { label: string; value: string; last?: 
       <span className="text-[11px] font-medium text-text-dim">{label}</span>
       <span className="text-[11px] font-semibold text-[var(--text)]">{value}</span>
     </div>
+  );
+}
+
+/** A row whose value is copied to the clipboard instead of opened. */
+function CopyRow({
+  icon,
+  label,
+  value,
+  last,
+}: {
+  icon: string;
+  label: string;
+  value: string;
+  last?: boolean;
+}) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  return (
+    <button
+      onClick={() => {
+        commands
+          .copyToClipboard(value)
+          .then(() => setCopied(true))
+          .catch(() => {});
+      }}
+      className={`flex w-full items-center gap-2.5 bg-[var(--tb-card)] px-4 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] ${
+        last ? "" : "border-b border-[var(--tb-border)]"
+      }`}
+    >
+      <span className="w-4 text-center text-xs">{icon}</span>
+      <span className="flex-1 text-[11px] font-medium text-[var(--text)]">{label}</span>
+      <span className="font-mono text-[11px] text-text-dim">{value}</span>
+      <span className="w-12 text-right text-[10px] text-text-faint">
+        {copied ? t("common.copied") : t("common.copy")}
+      </span>
+    </button>
   );
 }
 

--- a/src/features/toolbox/AboutTab.tsx
+++ b/src/features/toolbox/AboutTab.tsx
@@ -7,8 +7,9 @@ import { useUpdateStore } from "../../lib/stores/update-store";
 import { UpdateDialog } from "../shared/UpdateDialog";
 import type { UpdateInfoDto } from "../../lib/types";
 
-/** Contact for players who cannot or will not use GitHub. Also listed on the site. */
+/** Community contacts for players who cannot or will not use GitHub. Also on the site. */
 const QQ_CONTACT = "2157875454";
+const DISCORD_INVITE = "https://discord.gg/uUn9aAm9ww";
 
 export function AboutTab() {
   const { t } = useTranslation();
@@ -147,7 +148,12 @@ export function AboutTab() {
           label={t("toolbox.about.issues")}
           onClick={() => openExternal("https://github.com/lshw54/maplelink/issues")}
         />
-        <CopyRow icon="💬" label={t("toolbox.about.qq")} value={QQ_CONTACT} last />
+        <LinkRow
+          icon="💬"
+          label={t("toolbox.about.discord")}
+          onClick={() => openExternal(DISCORD_INVITE)}
+        />
+        <CopyRow icon="🐧" label={t("toolbox.about.qq")} value={QQ_CONTACT} last />
       </div>
 
       {/* Copyright */}

--- a/src/features/toolbox/AboutTab.tsx
+++ b/src/features/toolbox/AboutTab.tsx
@@ -125,6 +125,16 @@ export function AboutTab() {
       {/* Links */}
       <div className="overflow-hidden rounded-[10px] border border-[var(--tb-border)]">
         <LinkRow
+          icon="🌐"
+          label={t("toolbox.about.website")}
+          onClick={() => openExternal("https://lshw54.github.io/maplelink/")}
+        />
+        <LinkRow
+          icon="📖"
+          label={t("toolbox.about.guide")}
+          onClick={() => openExternal("https://lshw54.github.io/maplelink/guide")}
+        />
+        <LinkRow
           icon="🔗"
           label={t("toolbox.about.github_project")}
           onClick={() => openExternal("https://github.com/lshw54/maplelink")}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -285,6 +285,8 @@
   "toolbox.about.backend": "Backend",
   "toolbox.about.platform": "Platform",
   "toolbox.about.license_label": "License",
+  "toolbox.about.website": "Official Website",
+  "toolbox.about.guide": "Getting Started / FAQ",
   "toolbox.about.github_project": "GitHub Project",
   "toolbox.about.issues": "Report Issues / Feature Requests",
   "toolbox.about.disclaimer": "This is NOT an official Gamania product. Use at your own risk. Make sure you trust where you got this from.",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -289,6 +289,7 @@
   "toolbox.about.guide": "Getting Started / FAQ",
   "toolbox.about.github_project": "GitHub Project",
   "toolbox.about.issues": "Report Issues / Feature Requests",
+  "toolbox.about.qq": "Contact us on QQ",
   "toolbox.about.disclaimer": "This is NOT an official Gamania product. Use at your own risk. Make sure you trust where you got this from.",
   "update.title": "Update Available",
   "update.new_version_available": "A new version is ready to download",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -289,6 +289,7 @@
   "toolbox.about.guide": "Getting Started / FAQ",
   "toolbox.about.github_project": "GitHub Project",
   "toolbox.about.issues": "Report Issues / Feature Requests",
+  "toolbox.about.discord": "Discord community",
   "toolbox.about.qq": "Contact us on QQ",
   "toolbox.about.disclaimer": "This is NOT an official Gamania product. Use at your own risk. Make sure you trust where you got this from.",
   "update.title": "Update Available",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -289,6 +289,7 @@
   "toolbox.about.guide": "新手教学 / 常见问题",
   "toolbox.about.github_project": "GitHub 项目页",
   "toolbox.about.issues": "报告问题 / 功能建议",
+  "toolbox.about.qq": "QQ 联系",
   "toolbox.about.disclaimer": "本程序并非游戏橘子官方产品。使用前请自行评估风险，并确认下载来源是否安全。",
   "update.title": "有可用更新",
   "update.new_version_available": "新版本已准备好下载",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -289,6 +289,7 @@
   "toolbox.about.guide": "新手教学 / 常见问题",
   "toolbox.about.github_project": "GitHub 项目页",
   "toolbox.about.issues": "报告问题 / 功能建议",
+  "toolbox.about.discord": "Discord 社群",
   "toolbox.about.qq": "QQ 联系",
   "toolbox.about.disclaimer": "本程序并非游戏橘子官方产品。使用前请自行评估风险，并确认下载来源是否安全。",
   "update.title": "有可用更新",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -285,6 +285,8 @@
   "toolbox.about.backend": "后端 / Shell",
   "toolbox.about.platform": "平台",
   "toolbox.about.license_label": "授权",
+  "toolbox.about.website": "官方网站",
+  "toolbox.about.guide": "新手教学 / 常见问题",
   "toolbox.about.github_project": "GitHub 项目页",
   "toolbox.about.issues": "报告问题 / 功能建议",
   "toolbox.about.disclaimer": "本程序并非游戏橘子官方产品。使用前请自行评估风险，并确认下载来源是否安全。",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -289,6 +289,7 @@
   "toolbox.about.guide": "新手教學 / 常見問題",
   "toolbox.about.github_project": "GitHub 專案頁",
   "toolbox.about.issues": "回報問題 / 功能建議",
+  "toolbox.about.qq": "QQ 聯絡",
   "toolbox.about.disclaimer": "本程式並非遊戲橘子官方產品。使用前請自行評估風險，並確認下載來源是否安全。",
   "update.title": "有可用更新",
   "update.new_version_available": "新版本已準備好下載",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -285,6 +285,8 @@
   "toolbox.about.backend": "後端 / Shell",
   "toolbox.about.platform": "平台",
   "toolbox.about.license_label": "授權",
+  "toolbox.about.website": "官方網站",
+  "toolbox.about.guide": "新手教學 / 常見問題",
   "toolbox.about.github_project": "GitHub 專案頁",
   "toolbox.about.issues": "回報問題 / 功能建議",
   "toolbox.about.disclaimer": "本程式並非遊戲橘子官方產品。使用前請自行評估風險，並確認下載來源是否安全。",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -289,6 +289,7 @@
   "toolbox.about.guide": "新手教學 / 常見問題",
   "toolbox.about.github_project": "GitHub 專案頁",
   "toolbox.about.issues": "回報問題 / 功能建議",
+  "toolbox.about.discord": "Discord 社群",
   "toolbox.about.qq": "QQ 聯絡",
   "toolbox.about.disclaimer": "本程式並非遊戲橘子官方產品。使用前請自行評估風險，並確認下載來源是否安全。",
   "update.title": "有可用更新",


### PR DESCRIPTION
## What

- Point both READMEs and the toolbox About tab at the new official website (download, guide, FAQ).
- Add the community contacts — the Discord invite and QQ — to the About tab, both READMEs, the site landing page and the site FAQ.
- Re-lay the About tab's links as a two-column tile grid with drawn icons instead of emoji.
- Replace the wordy "where to get help" sentences on the site with plain link lists, and shorten the navbar locale labels to 繁中 / 简中 / EN.

## Why

The site has been live for a week and nothing pointed at it: the README still sent people straight to the Releases page, and the app had no link at all. Players who cannot or will not use GitHub also had no way to reach us, which is what the QQ contact and the new Discord server are for.

The About tab had grown to six stacked rows of emoji-led links, which read as one long wall, and the emoji rendered at different weights depending on the player's installed fonts. Tiles with drawn glyphs fit the same six links in half the height and look like one set.

## How to test

- `npm run dev`, open `/mock.html`, go to the toolbox and pick 關於. The six tiles should sit two per line, the GitHub and Discord marks should be recognisable, and clicking the QQ tile should flip its number to 已複製 for a moment.
- Narrow the window to 620px (the compact toolbox width) and check nothing truncates.
- `npm run build --prefix site`, then `npm run serve --prefix site`: the 遇到問題 column and the FAQ's 如何回報問題 answer should each end in a `Discord · GitHub Issues · QQ` line, and the navbar language switcher should read 繁中.

## Checklist

- [x] `cargo clippy -- -D warnings` passes — not run, no Rust changed
- [x] `npm run lint` passes
- [x] `npx tsc -b`, `npx prettier --check` and `npx vitest run` pass
- [x] Docusaurus builds for all three locales
- [x] Tested locally with `cargo tauri dev` — used the browser mock instead
- [x] No breaking changes to existing features
