### PR TITLE
fix(ui): set the secondary text tones by contrast so they can actually be read

### DIFF
--- a/site/src/demo/ml.css
+++ b/site/src/demo/ml.css
@@ -12,8 +12,10 @@
   --ml-surface-hover: rgba(255, 255, 255, 0.07);
   --ml-border: rgba(255, 255, 255, 0.08);
   --ml-text: rgba(255, 255, 255, 0.88);
-  --ml-dim: rgba(255, 255, 255, 0.45);
-  --ml-faint: rgba(255, 255, 255, 0.22);
+  /* Matches the app's own tokens, which are set by contrast rather than by
+     eye — see globals.css and the text-contrast test. */
+  --ml-dim: rgba(255, 255, 255, 0.62);
+  --ml-faint: rgba(255, 255, 255, 0.48);
   --ml-green: #4ade80;
   --ml-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-family: "Microsoft YaHei UI", "Microsoft YaHei", "Microsoft JhengHei UI", "Microsoft JhengHei", "Segoe UI", "PingFang TC", system-ui, -apple-system, sans-serif;

--- a/src/lib/__tests__/text-contrast.test.ts
+++ b/src/lib/__tests__/text-contrast.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+// The stylesheet is the thing under test, so it is read rather than restated.
+const css = readFileSync(new URL("../../styles/globals.css", import.meta.url), "utf8");
+
+/**
+ * Secondary text has to stay readable.
+ *
+ * `--text-dim` and `--text-faint` used to be picked by eye and drifted far
+ * below the point where they could be read: 4.5 and 1.9 to one in dark, 2.9
+ * and 1.7 in light. Players reported exactly that. These tests pin them to
+ * WCAG AA's 4.5 for body text, measured against the worst surface each one
+ * lands on, so the next adjustment by eye fails here instead of shipping.
+ */
+type Rgb = [number, number, number];
+
+function relativeLuminance([r, g, b]: Rgb): number {
+  const f = (c: number) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+function contrast(fg: Rgb, bg: Rgb): number {
+  const a = relativeLuminance(fg);
+  const b = relativeLuminance(bg);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+/** Flatten a translucent white onto the surface behind it. */
+function whiteAt(alpha: number, bg: Rgb): Rgb {
+  return bg.map((c) => Math.round(255 * alpha + c * (1 - alpha))) as Rgb;
+}
+
+function hex(value: string): Rgb {
+  const v = value.replace("#", "");
+  return [parseInt(v.slice(0, 2), 16), parseInt(v.slice(2, 4), 16), parseInt(v.slice(4, 6), 16)];
+}
+
+/** hsl() the way `accent.ts` writes the tinted surfaces. */
+function hsl(h: number, s: number, l: number): Rgb {
+  const sat = s / 100;
+  const light = l / 100;
+  const c = (1 - Math.abs(2 * light - 1)) * sat;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = light - c / 2;
+  const [r, g, b] =
+    h < 60
+      ? [c, x, 0]
+      : h < 120
+        ? [x, c, 0]
+        : h < 180
+          ? [0, c, x]
+          : h < 240
+            ? [0, x, c]
+            : h < 300
+              ? [x, 0, c]
+              : [c, 0, x];
+  return [r, g, b].map((v) => Math.round((v + m) * 255)) as Rgb;
+}
+
+/** The value of `name` inside the first block matching `scope`. */
+function token(scope: string, name: string): string {
+  const block = css.slice(css.indexOf(scope));
+  const value = new RegExp(`${name}:\\s*([^;]+);`).exec(block)?.[1];
+  if (value === undefined) throw new Error(`${name} not found after ${scope}`);
+  return value.trim();
+}
+
+function alphaOf(value: string): number {
+  const alpha = /rgba\(255,\s*255,\s*255,\s*([\d.]+)\)/.exec(value)?.[1];
+  if (alpha === undefined) throw new Error(`not a translucent white: ${value}`);
+  return Number(alpha);
+}
+
+/** WCAG AA for body text. */
+const AA = 4.5;
+
+describe("dark theme secondary text", () => {
+  // The lightest surface text sits on, so the tightest contrast: --tb-card.
+  const card = hex("#141619");
+
+  it("dim text clears AA on the lightest surface", () => {
+    const alpha = alphaOf(token(":root", "--text-dim"));
+    expect(contrast(whiteAt(alpha, card), card)).toBeGreaterThanOrEqual(AA);
+  });
+
+  it("faint text clears AA on the lightest surface", () => {
+    const alpha = alphaOf(token(":root", "--text-faint"));
+    expect(contrast(whiteAt(alpha, card), card)).toBeGreaterThanOrEqual(AA);
+  });
+
+  it("clears AA on a card tinted by any accent hue", () => {
+    // accent.ts sets --card-user to hsl(h 11% 8.8%).
+    const dim = alphaOf(token(":root", "--text-dim"));
+    const faint = alphaOf(token(":root", "--text-faint"));
+    for (let h = 0; h < 360; h += 10) {
+      const tinted = hsl(h, 11, 8.8);
+      expect(contrast(whiteAt(dim, tinted), tinted), `dim at hue ${h}`).toBeGreaterThanOrEqual(AA);
+      expect(contrast(whiteAt(faint, tinted), tinted), `faint at hue ${h}`).toBeGreaterThanOrEqual(
+        AA,
+      );
+    }
+  });
+
+  it("keeps the three tones visibly apart", () => {
+    const text = alphaOf(token(":root", "--text"));
+    const dim = alphaOf(token(":root", "--text-dim"));
+    const faint = alphaOf(token(":root", "--text-faint"));
+    expect(text).toBeGreaterThan(dim);
+    expect(dim).toBeGreaterThan(faint);
+    expect(dim - faint).toBeGreaterThanOrEqual(0.1);
+  });
+});
+
+describe("light theme secondary text", () => {
+  // Here the page itself is the darkest surface, so it is the tightest.
+  const page = hex("#e6e6ea");
+
+  it("dim and faint text clear AA on the page", () => {
+    expect(contrast(hex(token(".light", "--text-dim")), page)).toBeGreaterThanOrEqual(AA);
+    expect(contrast(hex(token(".light", "--text-faint")), page)).toBeGreaterThanOrEqual(AA);
+  });
+
+  it("clears AA on a page tinted by any accent hue", () => {
+    // accent.ts sets --bg-user-light to hsl(h 42% 90%).
+    const dim = hex(token(".light", "--text-dim"));
+    const faint = hex(token(".light", "--text-faint"));
+    for (let h = 0; h < 360; h += 10) {
+      const tinted = hsl(h, 42, 90);
+      expect(contrast(dim, tinted), `dim at hue ${h}`).toBeGreaterThanOrEqual(AA);
+      expect(contrast(faint, tinted), `faint at hue ${h}`).toBeGreaterThanOrEqual(AA);
+    }
+  });
+});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -31,9 +31,14 @@
     --surface: rgba(255, 255, 255, 0.04);
     --surface-hover: rgba(255, 255, 255, 0.07);
     --border: rgba(255, 255, 255, 0.08);
+    /* The secondary tones are set by contrast, not by eye. Against the
+       lightest surface they sit on (--tb-card, #141619) these give 14.1,
+       7.5 and 5.0 to one; WCAG AA wants 4.5 for body text, and the old
+       values were 4.5 and 1.9 — the faint one was decorative rather than
+       readable, which is exactly what players reported. */
     --text: rgba(255, 255, 255, 0.88);
-    --text-dim: rgba(255, 255, 255, 0.45);
-    --text-faint: rgba(255, 255, 255, 0.22);
+    --text-dim: rgba(255, 255, 255, 0.62);
+    --text-faint: rgba(255, 255, 255, 0.48);
     --glow-bg: rgba(var(--accent-rgb), 0.06);
     --input-focus-ring: rgba(var(--accent-rgb), 0.08);
     --tb-bg: var(--bg-user, #090b0f);
@@ -51,9 +56,14 @@
     --surface: rgba(0, 0, 0, 0.04);
     --surface-hover: rgba(0, 0, 0, 0.08);
     --border: rgba(0, 0, 0, 0.12);
+    /* Same rule against this theme's darkest surface, the page itself, and
+       checked against every accent hue the page can be tinted with (the
+       worst of those is what these numbers are): 12.3, 5.4 and 4.7 to one.
+       The old pair managed 2.9 and 1.7, so light mode was the worse of the
+       two to read. */
     --text: #1d1d1f;
-    --text-dim: #86868b;
-    --text-faint: #b0b0b5;
+    --text-dim: #55555a;
+    --text-faint: #5e5e63;
     --glow-bg: rgba(var(--accent-rgb), 0.04);
     --input-focus-ring: rgba(var(--accent-rgb), 0.12);
     --tb-bg: var(--bg-user-light, #e6e6ea);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    // Explicit, because a test reads globals.css off disk to check its
+    // contrast ratios. Naming them also stops transitive @types packages
+    // from leaking globals into app code.
+    "types": ["node", "vite/client"],
     "jsx": "react-jsx",
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## What
Secondary text was too dark to read. `--text-dim` and `--text-faint` had been picked by eye and had drifted well below the point where they are legible; this sets them by measured contrast instead, in both themes.

| Token | Before | After | WCAG AA |
|---|---|---|---|
| dark `--text-dim` | 4.52 | 7.46 | 4.5 |
| dark `--text-faint` | **1.92** | 4.97 | 4.5 |
| light `--text-dim` | **2.91** | 5.44 | 4.5 |
| light `--text-faint` | **1.74** | 4.73 | 4.5 |

Each is measured against the tightest surface it lands on — the lightest card in dark mode, the page itself in light mode — and then re-checked across every accent hue the surfaces can be tinted with, taking the worst. The three tones stay visibly apart (14.1 / 7.5 / 5.0 in dark).

Six tests read the tokens straight out of `globals.css` and fail if any of them drops below AA, so the next adjustment by eye cannot ship. The demo palette on the website is matched to the same values.

## Why

Reported by players, who said beanfun's own launcher reads more clearly. It does: at 1.92 to one, faint text is decorative rather than readable, and light mode was the worse of the two because even `--text-dim` — the workhorse for secondary copy — failed.

The custom accent colour was suspected first. It is not the cause: accent-coloured text measures 8.6 to one in the green a player reported with, against 9.1 for the default orange. `applyAccent()` already holds surface lightness fixed while changing only hue, so contrast survives any accent.

## How to test

1. Open the login page in dark mode. The cafe-mode description and the version line at the bottom should now be readable rather than a smudge.
2. Switch to light mode and check the same places; this is where the change is largest.
3. Set a custom accent (Settings → appearance) in several hues and confirm secondary text stays readable in both themes.
4. `npx vitest run src/lib/__tests__/text-contrast.test.ts`.

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes
- [ ] Tested locally with `cargo tauri dev` — checked through the browser mock in both themes, plus the contrast tests
- [x] No breaking changes to existing features

Also green: `cargo fmt --all --check`, `cargo test` (231), `prettier --check`, `tsc -b`, `vitest` (15), and a three-locale site build.
