### PR TITLE
fix(ui): show what actually failed instead of [object Object]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { MainPage } from "./features/launcher/MainPage";
 import { ToolboxPage } from "./features/toolbox/ToolboxPage";
 import { WebLaunchPage } from "./features/toolbox/WebLaunchPage";
 import type { UpdateInfoDto, BeanfunRenameCheck, ClassicAccountDto } from "./lib/types";
+import { errorMessage } from "./lib/errors";
 
 function PageRouter() {
   const currentPage = useUiStore((s) => s.currentPage);
@@ -411,7 +412,7 @@ export function App() {
             commands.applyBeanfunRename().catch((err) => {
               setRenameCheck(null);
               useErrorToastStore.getState().addToast({
-                message: err instanceof Error ? err.message : String(err),
+                message: errorMessage(err),
                 category: "process",
                 critical: false,
               });

--- a/src/features/client/ClientManagerApp.tsx
+++ b/src/features/client/ClientManagerApp.tsx
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useTranslation } from "../../lib/i18n";
 import { commands } from "../../lib/tauri";
+import { errorMessage } from "../../lib/errors";
 // The same hooks the main window uses, so both react to theme, language and
 // accent identically instead of drifting apart.
 import { useInitialConfigSync, useThemeEffect } from "../../lib/hooks/use-app-chrome";
@@ -252,7 +253,7 @@ export function ClientManagerApp() {
       setPhase("scanned");
       return r;
     } catch (e) {
-      setError(String(e));
+      setError(errorMessage(e));
       setPhase("idle");
       return null;
     }
@@ -288,7 +289,7 @@ export function ClientManagerApp() {
         setError(t("client.manifest_still_offline"));
       }
     } catch (e) {
-      setError(String(e));
+      setError(errorMessage(e));
     } finally {
       setRefreshing(false);
     }
@@ -313,7 +314,7 @@ export function ClientManagerApp() {
         }
       } catch (e) {
         if (!live) return;
-        setError(String(e));
+        setError(errorMessage(e));
         setPhase("idle");
       }
     })();
@@ -336,7 +337,7 @@ export function ClientManagerApp() {
         setOutcome(r);
         setPhase("done");
       } catch (e) {
-        setError(String(e));
+        setError(errorMessage(e));
         setPhase("scanned");
       }
     },

--- a/src/features/launcher/AddServiceAccountDialog.tsx
+++ b/src/features/launcher/AddServiceAccountDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "../../lib/i18n";
 import { commands } from "../../lib/tauri";
 import { useAuthStore } from "../../lib/stores/auth-store";
 import { useErrorToastStore } from "../../lib/stores/error-toast-store";
+import { errorMessage } from "../../lib/errors";
 
 /** beanfun's handler returns the contract as newline-separated plain text.
  *  Tags are stripped anyway in case the HK handler ever wraps it in markup,
@@ -74,8 +75,7 @@ export function AddServiceAccountDialog({
       setContract(text ? contractToText(text) : "");
     } catch (e) {
       // Surface beanfun's / the bridge's own error so a refusal is diagnosable.
-      const err = e as { message?: string } | string;
-      setContractError(typeof err === "string" ? err : (err?.message ?? String(e)));
+      setContractError(errorMessage(e));
       setContract("");
     } finally {
       setContractLoading(false);

--- a/src/features/launcher/MainPage.tsx
+++ b/src/features/launcher/MainPage.tsx
@@ -17,6 +17,7 @@ import { useGameAccounts } from "../../lib/hooks/use-accounts";
 import { StatusBar } from "../shared/StatusBar";
 import { Modal } from "../../components/Modal";
 import type { GameAccountDto, ClassicCheckDto } from "../../lib/types";
+import { errorMessage } from "../../lib/errors";
 
 export function MainPage() {
   const { t } = useTranslation();
@@ -249,10 +250,7 @@ export function MainPage() {
           setGameRunning(true);
         }
       } catch (err) {
-        const msg =
-          typeof err === "object" && err !== null && "message" in err
-            ? String((err as Record<string, unknown>).message)
-            : String(err);
+        const msg = errorMessage(err);
         useErrorToastStore.getState().addToast({
           message: msg,
           category: "process",

--- a/src/features/login/LoginPage.tsx
+++ b/src/features/login/LoginPage.tsx
@@ -15,6 +15,7 @@ import { QrLoginForm } from "./QrLoginForm";
 import { TotpForm } from "./TotpForm";
 import { VerifyForm } from "./VerifyForm";
 import type { SessionDto } from "../../lib/types";
+import { errorMessage } from "../../lib/errors";
 
 type LoginView = "normal" | "qr" | "totp" | "verify" | "gamepass";
 
@@ -110,10 +111,7 @@ export function LoginPage() {
   const handleGamePass = useCallback(() => {
     setView("gamepass");
     commands.openGamePassLogin().catch((err) => {
-      const msg =
-        typeof err === "object" && err !== null && "message" in err
-          ? String((err as Record<string, unknown>).message)
-          : String(err);
+      const msg = errorMessage(err);
       useErrorToastStore.getState().addToast({
         message: msg,
         category: "authentication",
@@ -286,10 +284,7 @@ async function doDirectLaunch() {
       setGameRunning(true);
     }
   } catch (err) {
-    const msg =
-      typeof err === "object" && err !== null && "message" in err
-        ? String((err as Record<string, unknown>).message)
-        : String(err);
+    const msg = errorMessage(err);
     useErrorToastStore.getState().addToast({
       message: msg,
       category: "process",

--- a/src/features/login/QrLoginForm.tsx
+++ b/src/features/login/QrLoginForm.tsx
@@ -7,6 +7,7 @@ import { useConfigStore } from "../../lib/stores/config-store";
 import { finishLogin } from "../../lib/hooks/use-auth";
 import { useQueryClient } from "@tanstack/react-query";
 import type { QrCodeData, QrPollResult } from "../../lib/types";
+import { errorMessage } from "../../lib/errors";
 
 /**
  * The QR image as a PNG blob, decoded from the `data:` URL it arrives in.
@@ -181,11 +182,7 @@ export function QrLoginForm({ onBack }: QrLoginFormProps) {
 
       startPolling(sessionId, data);
     } catch (err) {
-      setError(
-        typeof err === "object" && err !== null && "message" in err
-          ? String((err as Record<string, unknown>).message)
-          : String(err),
-      );
+      setError(errorMessage(err));
       setStatus("error");
       startedRef.current = false;
     }

--- a/src/features/login/VerifyForm.tsx
+++ b/src/features/login/VerifyForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "../../lib/i18n";
 import { commands } from "../../lib/tauri";
+import { errorMessage } from "../../lib/errors";
 import { useAuthStore } from "../../lib/stores/auth-store";
 import { useLogin } from "../../lib/hooks/use-auth";
 import type { AdvanceCheckState } from "../../lib/types";
@@ -11,20 +12,6 @@ interface VerifyFormProps {
   onVerified: () => void;
   onAdvanceCheck: (url?: string) => void;
   onTotpRequired: () => void;
-}
-
-function extractErrorMessage(err: unknown): string {
-  if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null) {
-    const obj = err as Record<string, unknown>;
-    if (typeof obj.message === "string" && obj.message) return obj.message;
-    try {
-      return JSON.stringify(err);
-    } catch {
-      /* fallback */
-    }
-  }
-  return String(err);
 }
 
 export function VerifyForm({
@@ -57,7 +44,7 @@ export function VerifyForm({
       setCheckState(state);
       setCaptchaImage(state.captchaImageBase64);
     } catch (err) {
-      const msg = extractErrorMessage(err);
+      const msg = errorMessage(err);
       if (msg.includes("advance_check_web:")) {
         const url = msg.replace("advance_check_web:", "").replace("Invalid credentials: ", "");
         setWebVerifyUrl(url);
@@ -167,7 +154,7 @@ export function VerifyForm({
         }
       }
     } catch (err) {
-      setError(extractErrorMessage(err));
+      setError(errorMessage(err));
       await handleRefreshCaptcha();
     } finally {
       setSubmitting(false);

--- a/src/features/toolbox/WebLaunchTab.tsx
+++ b/src/features/toolbox/WebLaunchTab.tsx
@@ -4,6 +4,7 @@ import { useConfigStore } from "../../lib/stores/config-store";
 import { useSetConfig } from "../../lib/hooks/use-config";
 import { commands } from "../../lib/tauri";
 import type { WebLaunchStatus, WebLaunchTestCode } from "../../lib/types";
+import { errorMessage } from "../../lib/errors";
 
 type CheckState = "ok" | "bad";
 
@@ -181,9 +182,7 @@ export function WebLaunchTab() {
       await commands.setWebLaunchIntercept(next);
       setToggleMsg(next ? t("web_launch.enabled_msg") : t("web_launch.disabled_msg"));
     } catch (e) {
-      setToggleMsg(
-        `${t("web_launch.toggle_failed")}: ${e instanceof Error ? e.message : String(e)}`,
-      );
+      setToggleMsg(`${t("web_launch.toggle_failed")}: ${errorMessage(e)}`);
     } finally {
       setToggling(false);
       await refresh();

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { errorMessage } from "../errors";
+import type { ErrorDto } from "../types";
+
+describe("errorMessage", () => {
+  it("never renders an object as [object Object]", () => {
+    // The reported bug: a red box reading exactly this, in every locale,
+    // with nothing to act on.
+    const dto: ErrorDto = {
+      code: "CLIENT_MANIFEST_FAILED",
+      message: "product list request failed: error sending request",
+      category: "network",
+    };
+    const shown = errorMessage(dto);
+    expect(shown).not.toContain("[object Object]");
+    expect(shown).toContain("product list request failed");
+    // The code is what makes a screenshot reportable.
+    expect(shown).toContain("CLIENT_MANIFEST_FAILED");
+  });
+
+  it("falls back to the code when the backend sent no message", () => {
+    expect(errorMessage({ code: "SYS_PATH_ERROR", message: "", category: "process" })).toBe(
+      "SYS_PATH_ERROR",
+    );
+    expect(
+      errorMessage({ code: "SYS_PATH_ERROR", message: "", category: "process", details: "C:\\x" }),
+    ).toBe("SYS_PATH_ERROR: C:\\x");
+  });
+
+  it("reads an Error and a plain string", () => {
+    expect(errorMessage(new Error("disk full"))).toBe("disk full");
+    expect(errorMessage("game path is not set")).toBe("game path is not set");
+  });
+
+  it("serialises an object it does not recognise rather than hiding it", () => {
+    expect(errorMessage({ reason: "odd", attempt: 2 })).toBe('{"reason":"odd","attempt":2}');
+  });
+
+  it("survives the awkward values a rejection can carry", () => {
+    expect(errorMessage(undefined)).toBe("undefined");
+    expect(errorMessage(null)).toBe("null");
+    expect(errorMessage(404)).toBe("404");
+    expect(errorMessage("   ")).toBe("   ");
+    expect(errorMessage(new Error(""))).toBe("Error");
+    expect(errorMessage({})).toBe("{}");
+
+    // A circular object cannot be serialised; it must still not throw.
+    const loop: Record<string, unknown> = {};
+    loop.self = loop;
+    expect(() => errorMessage(loop)).not.toThrow();
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Turn whatever a rejected promise carried into something worth showing.
+ *
+ * Tauri commands reject with an `ErrorDto` — a plain object, not an `Error` —
+ * so `String(e)` on one yields `[object Object]`. That is what players were
+ * seeing in the client manager: a red box with no information in it, and
+ * nothing anyone could act on or report.
+ *
+ * The code is appended when there is one. It is noise to read, but it is the
+ * part that makes a screenshot useful: it says which command failed without
+ * anyone having to reproduce it.
+ */
+export function errorMessage(err: unknown): string {
+  if (typeof err === "string") {
+    const text = err.trim();
+    if (text) return text;
+  } else if (err instanceof Error) {
+    if (err.message) return err.message;
+  } else if (typeof err === "object" && err !== null) {
+    const shape = err as Record<string, unknown>;
+    const message = typeof shape.message === "string" ? shape.message.trim() : "";
+    const code = typeof shape.code === "string" ? shape.code.trim() : "";
+    const details = typeof shape.details === "string" ? shape.details.trim() : "";
+
+    if (message && code) return `${message} (${code})`;
+    if (message) return message;
+    if (code) return details ? `${code}: ${details}` : code;
+
+    // Some other object. Its JSON is ugly but it is information, which
+    // `[object Object]` is not.
+    try {
+      const json = JSON.stringify(err);
+      // `{}` included: an empty object says nothing, but it says it honestly,
+      // and it is distinguishable from the `[object Object]` this replaces.
+      if (json) return json;
+    } catch {
+      /* circular, or something that will not serialise */
+    }
+  }
+  return String(err);
+}

--- a/src/lib/hooks/use-auth.ts
+++ b/src/lib/hooks/use-auth.ts
@@ -6,6 +6,7 @@ import { useConfigStore } from "../stores/config-store";
 import { useUiStore } from "../stores/ui-store";
 import { useErrorToastStore } from "../stores/error-toast-store";
 import type { SessionDto } from "../types";
+import { errorMessage } from "../errors";
 
 /** Translate outside React render (mutation callbacks) using the current language. */
 const tr = (key: string) => getTranslation(useUiStore.getState().language, key);
@@ -233,12 +234,7 @@ export function useLogin() {
         }
         // Login failed — clean up the session
         useAuthStore.getState().setPendingCredentials(null);
-        throw new Error(
-          typeof err === "object" && err !== null && "message" in err
-            ? String((err as Record<string, unknown>).message)
-            : String(err),
-          { cause: err },
-        );
+        throw new Error(errorMessage(err), { cause: err });
       }
     },
     onSuccess: (session: SessionDto) => finishLogin(queryClient, session),

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { errorMessage } from "./errors";
 import type {
   AccountLimitDto,
   AddServiceAccountDto,
@@ -283,6 +284,8 @@ export async function solveRecaptcha(
 
     commands
       .openRecaptchaWindow(step)
-      .catch((err) => finish(() => reject(err instanceof Error ? err : new Error(String(err)))));
+      .catch((err) =>
+        finish(() => reject(err instanceof Error ? err : new Error(errorMessage(err)))),
+      );
   });
 }


### PR DESCRIPTION
## What / 做了什麼

Players reported a red error box in the client manager reading exactly `[object Object]`, with nothing else in it.

Tauri commands reject with an `ErrorDto` — a plain object, not an `Error` — so `String(e)` on one produces that string and throws away the message the backend sent. This adds one `errorMessage()` helper and routes every error surface through it.

The same mistake was spread across the app in several shapes, so all of them are fixed rather than just the reported screen:

| Where | Before |
|---|---|
| Client manager, 4 sites | `String(e)` — the reported bug |
| Web-launch tab | Only handled `Error`, so an `ErrorDto` fell through the same way |
| Beanfun rename toast | Same |
| reCAPTCHA window wrapper | Wrapped it as `new Error("[object Object]")` |
| Login ×2, QR login, main page | Each carried its own copy of the same inline formatter |
| Verify form | Carried a whole local copy of the function |

`errorMessage()` takes a string as-is, reads `.message` off an `Error`, reads `message` and `code` off an `ErrorDto`, serialises any other object, and only then falls back to `String()`. The code is appended — `product list request failed: … (CLIENT_MANIFEST_FAILED)` — because that is the part that makes a screenshot reportable without anyone having to reproduce it.

## Why / 為什麼

The report could not be reproduced locally, and that is the point: the path only runs when a backend command genuinely fails. On a machine that can reach beanfun it never fires. A player behind a blocked DNS or a corporate firewall hits it immediately, and the box then tells them — and us — nothing at all.

Reproduced by rejecting `client_load_manifest` the way Tauri does: the box read `[object Object]`, matching the screenshot. With the fix it reads the message and the code.

## How to test / 如何測試

1. Disconnect from the network and open the client manager. The error box should name what failed and carry a code, not `[object Object]`.
2. Reconnect and press *Fetch again*; it should recover.
3. `npx vitest run src/lib/__tests__/errors.test.ts` — five cases, including the `[object Object]` regression, an empty object, and a circular one.

## Checklist

- [x] `cargo clippy -- -D warnings` passes
- [x] `npm run lint` passes
- [ ] Tested locally with `cargo tauri dev` — reproduced and verified through the browser mock, plus the unit tests
- [x] No breaking changes to existing features

Also green: `cargo fmt --all --check`, `cargo test` (231), `prettier --check`, `tsc -b`, `vitest` (20).
